### PR TITLE
Network update() call make sure _id is defined

### DIFF
--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -120,13 +120,7 @@ class Casambi:
         # Retrieve network information
         uuid = addr.replace(":", "").lower()
         self._casaNetwork = Network(uuid, self._httpClient)
-        await self._casaNetwork.getNetworkId()
-        if not self._casaNetwork.authenticated():
-            loggedIn = await self._casaNetwork.logIn(password)
-            if not loggedIn:
-                raise AuthenticationError("Login failed")
-        await self._casaNetwork.update()
-
+        await self._casaNetwork.logIn(password)
         await self._connectClient()
 
     async def _connectClient(self) -> None:

--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -121,6 +121,7 @@ class Casambi:
         uuid = addr.replace(":", "").lower()
         self._casaNetwork = Network(uuid, self._httpClient)
         await self._casaNetwork.logIn(password)
+        await self._casaNetwork.update()
         await self._connectClient()
 
     async def _connectClient(self) -> None:

--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -120,6 +120,7 @@ class Casambi:
         # Retrieve network information
         uuid = addr.replace(":", "").lower()
         self._casaNetwork = Network(uuid, self._httpClient)
+        await self._casaNetwork.getNetworkId()
         if not self._casaNetwork.authenticated():
             loggedIn = await self._casaNetwork.logIn(password)
             if not loggedIn:

--- a/src/CasambiBt/_network.py
+++ b/src/CasambiBt/_network.py
@@ -101,7 +101,12 @@ class Network:
     def getKeyStore(self) -> KeyStore:
         return self._keystore
 
-    async def logIn(self, password: str) -> bool:
+    async def logIn(self, password: str) -> None:
+        await self.getNetworkId()
+
+        if self.authenticated():
+            return
+
         self._logger.info(f"Logging in to network...")
         getSessionUrl = f"https://api.casambi.com/network/{self._id}/session"
 
@@ -117,10 +122,8 @@ class Network:
             self._session = _NetworkSession(**sessionJson)
             self._logger.info("Login sucessful.")
             self._saveSesion()
-            return True
         else:
-            self._logger.error(f"Login failed: {res.status_code}\n{res.text}")
-            return False
+            raise AuthenticationError(f"Login failed: {res.status_code}\n{res.text}")
 
     async def update(self) -> None:
         self._logger.info(f"Updating network...")

--- a/src/CasambiBt/_network.py
+++ b/src/CasambiBt/_network.py
@@ -102,8 +102,6 @@ class Network:
         return self._keystore
 
     async def logIn(self, password: str) -> bool:
-        await self.getNetworkId()
-
         self._logger.info(f"Logging in to network...")
         getSessionUrl = f"https://api.casambi.com/network/{self._id}/session"
 


### PR DESCRIPTION
If there was already a valid session the logIn() call is skipped and therefore the getNetworkId() was never made. This causes update() to fail because it needs the _id for the getNetworkUrl.

To fix it move the getNetworkId() call before logIn() or update() is called.