### PR TITLE
fix Unit is_on() for dimmable lights

### DIFF
--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -240,7 +240,6 @@ class Unit:
         if (
             self.unitType.get_control(UnitControlType.DIMMER)
             and self._state
-            and self._state.dimmer
         ):
             return self._on and self._state.dimmer > 0
         else:


### PR DESCRIPTION
I only have dimmable lights and in home assistant they are always shown as but they are off in real.

The problem seems to be that _on is always True and only the dimmer value is set to 0. The code seems to take care of that but the condition was wrong, self._state.dimmer would always be false when the dimmer is 0 thus it was going into the else branch which only return _on.

Just removing the condition makes it work because the dimmer value is checked in the return line anyway.