### PR TITLE
Add support for xy control

### DIFF
--- a/src/CasambiBt/__init__.py
+++ b/src/CasambiBt/__init__.py
@@ -5,4 +5,4 @@
 
 from ._casambi import Casambi
 from ._discover import discover
-from ._unit import Group, Scene, Unit, UnitControlType, UnitState, ColorSource
+from ._unit import ColorSource, Group, Scene, Unit, UnitControlType, UnitState

--- a/src/CasambiBt/__init__.py
+++ b/src/CasambiBt/__init__.py
@@ -5,4 +5,4 @@
 
 from ._casambi import Casambi
 from ._discover import discover
-from ._unit import Group, Scene, Unit, UnitControlType, UnitState
+from ._unit import Group, Scene, Unit, UnitControlType, UnitState, ColorSource

--- a/src/CasambiBt/_discover.py
+++ b/src/CasambiBt/_discover.py
@@ -19,7 +19,7 @@ async def discover() -> list[BLEDevice]:
 
     # Discover all devices in range
     try:
-        devices = await BleakScanner.discover()
+        devices_and_advertisements = await BleakScanner.discover(return_adv=True)
     except BleakDBusError as e:
         raise BluetoothError(e.dbus_error, e.dbus_error_details) from e
     except BleakError as e:
@@ -27,9 +27,9 @@ async def discover() -> list[BLEDevice]:
 
     # Filter out all devices that aren't primary communication endpoints for casambi networks
     discovered = []
-    for d in devices:
-        if "manufacturer_data" in d.metadata and 963 in d.metadata["manufacturer_data"]:
-            if CASA_UUID in d.metadata["uuids"]:
+    for key, (d, advertisement) in devices_and_advertisements.items():
+        if 963 in advertisement.manufacturer_data:
+            if CASA_UUID in advertisement.service_uuids:
                 _LOGGER.debug(f"Discovered networt at {d.address}")
                 discovered.append(d)
 

--- a/src/CasambiBt/_discover.py
+++ b/src/CasambiBt/_discover.py
@@ -27,7 +27,7 @@ async def discover() -> list[BLEDevice]:
 
     # Filter out all devices that aren't primary communication endpoints for casambi networks
     discovered = []
-    for key, (d, advertisement) in devices_and_advertisements.items():
+    for _, (d, advertisement) in devices_and_advertisements.items():
         if 963 in advertisement.manufacturer_data:
             if CASA_UUID in advertisement.service_uuids:
                 _LOGGER.debug(f"Discovered networt at {d.address}")

--- a/src/CasambiBt/_operation.py
+++ b/src/CasambiBt/_operation.py
@@ -11,6 +11,7 @@ class OpCode(IntEnum):
     SetColor = 7
     SetTemperature = 10
     SetState = 48
+    SetColorXY = 54
 
 
 class OperationsContext:

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -206,14 +206,19 @@ class UnitState:
     @temperature.deleter
     def temperature(self) -> None:
         self.temperature = None
-        
-    COLORSOURCE_RESOLUTION = 8
-    COLORSOURCE_MIN = 0
-    COLORSOURCE_MAX = 2**COLORSOURCE_RESOLUTION - 1
 
     @property
     def colorsource(self) -> Optional[int]:
         return self._colorsource
+
+    @colorsource.setter
+    def colorsource(self, value: int) -> None:
+        self._check_range(value, 0, 3)
+        self._colorsource = value
+
+    @colorsource.deleter
+    def colorsource(self) -> None:
+        self._colorsource = None
     
     XY_RESOLUTION = 11
 

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -41,6 +41,15 @@ class UnitControlType(Enum):
     """State isn't implemented. Control saved for debuggin purposes."""
 
 
+@unique
+class ColorSource(Enum):
+    """The possible values for the color source control."""
+
+    TEMPERATURE = 0
+    RGB = 1
+    XY = 2
+
+
 @dataclass(frozen=True, repr=True)
 class UnitControl:
     type: UnitControlType
@@ -93,7 +102,7 @@ class UnitState:
         self._white: Optional[int] = None
         self._temperature: Optional[int] = None
         self._vertical: Optional[int] = None
-        self._colorsource: Optional[int] = None
+        self._colorsource: Optional[ColorSource] = None
         self._xy: Optional[tuple[float, float]] = None
 
     def _check_range(
@@ -210,12 +219,11 @@ class UnitState:
         self.temperature = None
 
     @property
-    def colorsource(self) -> Optional[int]:
+    def colorsource(self) -> Optional[ColorSource]:
         return self._colorsource
 
     @colorsource.setter
-    def colorsource(self, value: int) -> None:
-        self._check_range(value, 0, 3)
+    def colorsource(self, value: ColorSource) -> None:
         self._colorsource = value
 
     @colorsource.deleter
@@ -344,7 +352,7 @@ class Unit:
             elif (
                 c.type == UnitControlType.COLORSOURCE and state.colorsource is not None
             ):
-                scaledValue = state.colorsource
+                scaledValue = state.colorsource.value
             elif c.type == UnitControlType.XY and state.xy is not None:
                 coordLen = c.length // 2
                 x, y = state.xy
@@ -431,11 +439,7 @@ class Unit:
                 # TODO: We should probalby try to make this number a bit more round
                 self._state.temperature = int(((cInt / tempMask) * tempRange) + c.min)
             elif c.type == UnitControlType.COLORSOURCE:
-                # 0 - TW (temperature)
-                # 1 - RGB??
-                # 2 - XY
-                # 3 - ???
-                self._state.colorsource = cInt
+                self._state.colorsource = ColorSource(cInt)
             elif c.type == UnitControlType.XY:
                 coordLen = c.length
                 xyMask = 2**coordLen - 1

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -441,7 +441,7 @@ class Unit:
             elif c.type == UnitControlType.COLORSOURCE:
                 self._state.colorsource = ColorSource(cInt)
             elif c.type == UnitControlType.XY:
-                coordLen = c.length
+                coordLen = c.length // 2
                 xyMask = 2**coordLen - 1
                 y = cInt & xyMask
                 x = (cInt >> coordLen) & xyMask

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -222,8 +222,6 @@ class UnitState:
     def colorsource(self) -> None:
         self._colorsource = None
 
-    XY_RESOLUTION = 11
-
     @property
     def xy(self) -> Optional[tuple[float, float]]:
         return self._xy
@@ -348,11 +346,10 @@ class Unit:
             ):
                 scaledValue = state.colorsource
             elif c.type == UnitControlType.XY and state.xy is not None:
+                coordLen = c.length // 2
                 x, y = state.xy
-                xyMask = 2**UnitState.XY_RESOLUTION - 1
-                scaledValue = (round(x * xyMask) << UnitState.XY_RESOLUTION) | round(
-                    y * xyMask
-                )
+                xyMask = 2**coordLen - 1
+                scaledValue = (round(x * xyMask) << coordLen) | round(y * xyMask)
             # Use default if unsupported type or unset value in state
             else:
                 scaledValue = c.default
@@ -440,9 +437,10 @@ class Unit:
                 # 3 - ???
                 self._state.colorsource = cInt
             elif c.type == UnitControlType.XY:
-                xyMask = 2**UnitState.XY_RESOLUTION - 1
+                coordLen = c.length
+                xyMask = 2**coordLen - 1
                 y = cInt & xyMask
-                x = cInt >> UnitState.XY_RESOLUTION
+                x = (cInt >> coordLen) & xyMask
                 self._state.xy = (x / xyMask, y / xyMask)
             elif c.type == UnitControlType.UNKOWN:
                 # Might be useful for implementing more state types


### PR DESCRIPTION
This PR adds
1. functionality to support fixtures with the xy color mode. It also adds the colorsource control as it is required to switch between temp, rgb and xy color control (see [here](https://developer.dev.casambi.com/#ws-device-xy-color)).
2. Also while using demo.py I found that `BLEDevice.metadata` is deprecated and therefore replaced the call as suggested [here](https://github.com/hbldh/bleak/discussions/1354)

### Known Limitations
- As `colorsource` is an additional control, the consumer (casambi-bt-hass) needs to set this property correctly. (https://github.com/lkempf/casambi-bt-hass/pull/84)
- In a different PR I saw that methods in `Casambi` are used as helpers, e.g. for setting temperature to directly change the attribute of a Unit or Group. How would the exact `OpCode` and binary format be found? Wireshark?