### PR TITLE
Fix bluetooth issues on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ pip install casambi-bt
 
 Have a look at `demo.py` for a small example.
 
-Please note this won't work on Mac OSX since it doesn't expose Bluetooth Mac addresses, which are needed to communicate with the Casambi APIs. Instead, try it on a Raspberry Pi!
+### MacOS
+
+MacOS [does not expose the Bluetooth MAC address via their official API](https://github.com/hbldh/bleak/issues/140),
+if you're running this library on MacOS, it will use an undocumented IOBluetooth API to get the MAC Address.
+Without the real MAC address the integration with Casambi will not work.
+If you're running into problems fetching the MAC address on MacOS, try it on a Raspberry Pi.
 
 ### Casambi network setup
 


### PR DESCRIPTION
Bleak added a flag that uses an undocumented API of MacOS to fetch the actual Bluetooth MAC address.
PR: https://github.com/hbldh/bleak/pull/1073
Docs: https://bleak.readthedocs.io/en/latest/backends/macos.html#bleak.backends.corebluetooth.scanner.CBScannerArgs.use_bdaddr

It was added a few years back, and works fine on my Mac running 14.6.1 (Sonoma).
I tested the same argument on a Raspberry Pi 4 running Raspberry Pi OS, where it worked fine as well, but to be safe the flag is only added when the OS is MacOS/OSX.