### PR TITLE
Add missing UnitType and UnitControl models

### DIFF
--- a/src/CasambiBt/__init__.py
+++ b/src/CasambiBt/__init__.py
@@ -5,4 +5,13 @@
 
 from ._casambi import Casambi
 from ._discover import discover
-from ._unit import ColorSource, Group, Scene, Unit, UnitControlType, UnitState
+from ._unit import (
+    ColorSource,
+    Group,
+    Scene,
+    Unit,
+    UnitControl,
+    UnitControlType,
+    UnitState,
+    UnitType,
+)


### PR DESCRIPTION
The classes `UnitType` and `UnitControl` were missing in this import, which prevent them from being imported like this:

```python
from entities import Unit, UnitState, UnitType, UnitControl, UnitControlType
```