### PR TITLE
Add switch event parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-![PyPI](https://img.shields.io/pypi/v/casambi-bt)
+![PyPI](https://img.shields.io/pypi/v/casambi-bt-revamped)
 [![Discord](https://img.shields.io/discord/1186445089317326888)](https://discord.gg/jgZVugfx)
 
-# A bluetooth based Python library for controlling Casambi networks
+# Casambi Bluetooth Revamped - Enhanced Python library for Casambi networks
 
-This library provides a currently **alpha quality** interface to Casambi-based lights over Bluetooth.
-The author is not associated with Casambi and the implementation is based on his own analysis of the protocol.
-This interface is not feature complete and was only tested with a very small network.
+This is an enhanced fork of the original [casambi-bt](https://github.com/lkempf/casambi-bt) library with additional features:
 
-If you want to check out my (slow) progress in writing a integration for Home Assistant using this library you can take a look at [https://github.com/lkempf/casambi-bt-hass/](https://github.com/lkempf/casambi-bt-hass/).
+- **Switch event support** - Receive button press/release events from Casambi switches
+- **Improved relay status handling** - Better support for relay units
+- **Bug fixes and improvements** - Various fixes based on real-world usage
 
-For a more mature solution using a gateway and the official Casambi API have a look at [https://github.com/hellqvio86/aiocasambi](https://github.com/hellqvio86/aiocasambi).
+This library provides a bluetooth interface to Casambi-based lights. It is not associated with Casambi.
+
+For Home Assistant integration using this library, see [casambi-bt-hass](https://github.com/rankjie/casambi-bt-hass).
 
 ## Getting started
 
 This library is available on PyPi:
 
 ```
-pip install casambi-bt
+pip install casambi-bt-revamped
 ```
 
 Have a look at `demo.py` for a small example.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ pip install casambi-bt
 
 Have a look at `demo.py` for a small example.
 
+### Switch Event Support
+
+This library now supports receiving switch button events:
+
+```python
+from CasambiBt import Casambi
+
+def handle_switch_event(event_data):
+    print(f"Switch event: Unit {event_data['unit_id']}, "
+          f"Button {event_data['button']}, "
+          f"Action: {event_data['event']}")
+
+casa = Casambi()
+# ... connect to network ...
+
+# Register switch event handler
+casa.registerSwitchEventHandler(handle_switch_event)
+
+# Events will be received when buttons are pressed/released
+```
+
 ### MacOS
 
 MacOS [does not expose the Bluetooth MAC address via their official API](https://github.com/hbldh/bleak/issues/140),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [metadata]
-name = casambi-bt
-version = 0.2.5
-author = lkempf
-author_email = pypi@lukas-kempf.de
-description = A minimal, unofficial implementation of a bluetooth client for casambi devices
+name = casambi-bt-revamped
+version = 0.3.7.dev3
+author = rankjie
+author_email = rankjie@gmail.com
+description = Enhanced Casambi Bluetooth client library with switch event support
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/lkempf/casambi-bt
+url = https://github.com/rankjie/casambi-bt
 classifiers =
     Programming Language :: Python :: 3.12
     License :: OSI Approved :: Apache Software License

--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -33,6 +33,7 @@ class Casambi:
         self._casaNetwork: Network | None = None
 
         self._unitChangedCallbacks: list[Callable[[Unit], None]] = []
+        self._switchEventCallbacks: list[Callable[[dict[str, Any]], None]] = []
         self._disconnectCallbacks: list[Callable[[], None]] = []
 
         self._logger = logging.getLogger(__name__)
@@ -417,6 +418,21 @@ class Casambi:
                 self._logger.error(
                     f"Changed state notification for unkown unit {data['id']}"
                 )
+        elif packetType == IncommingPacketType.SwitchEvent:
+            self._logger.debug(
+                f"Handling switch event: unit_id={data.get('unit_id')}, "
+                f"button={data.get('button')}, event={data.get('event')}"
+            )
+
+            # Notify listeners
+            for switch_handler in self._switchEventCallbacks:
+                try:
+                    switch_handler(data)
+                except Exception:
+                    self._logger.error(
+                        f"Exception occurred in switchEventCallback {switch_handler}.",
+                        exc_info=True,
+                    )
         else:
             self._logger.warning(f"Handler for type {packetType} not implemented!")
 
@@ -440,6 +456,36 @@ class Casambi:
         """
         self._unitChangedCallbacks.remove(handler)
         self._logger.debug(f"Removed unit changed handler {handler}")
+
+    def registerSwitchEventHandler(
+        self, handler: Callable[[dict[str, Any]], None]
+    ) -> None:
+        """Register a new handler for switch events.
+
+        This handler is called whenever a switch event is received.
+        The handler is supplied with a dictionary containing:
+        - unit_id: The ID of the switch unit
+        - button: The button number that was pressed/released
+        - event: Either "button_press" or "button_release"
+        - message_type: The raw message type (0x08 or 0x10)
+        - flags: Additional flags from the message
+        - extra_data: Any additional data from the message
+
+        :param handler: The method to call when a switch event is received.
+        """
+        self._switchEventCallbacks.append(handler)
+        self._logger.debug(f"Registered switch event handler {handler}")
+
+    def unregisterSwitchEventHandler(
+        self, handler: Callable[[dict[str, Any]], None]
+    ) -> None:
+        """Unregister an existing switch event handler.
+
+        :param handler: The handler to unregister.
+        :raises ValueError: If the handler isn't registered.
+        """
+        self._switchEventCallbacks.remove(handler)
+        self._logger.debug(f"Removed switch event handler {handler}")
 
     def registerDisconnectCallback(self, callback: Callable[[], None]) -> None:
         """Register a disconnect callback.

--- a/src/CasambiBt/_client.py
+++ b/src/CasambiBt/_client.py
@@ -694,10 +694,10 @@ class CasambiClient:
             f"action={action_display} ({event_string}), flags=0x{flags:02x}"
         )
 
-        # Filter out type 0x08 messages with button=0 (likely notifications)
-        if message_type == 0x08 and button == 0:
+        # Filter out all type 0x08 messages
+        if message_type == 0x08:
             self._logger.debug(
-                f"Filtering out type 0x08 notification event: button={button}, unit_id={unit_id}, "
+                f"Filtering out type 0x08 event: button={button}, unit_id={unit_id}, "
                 f"action={action_display}, flags=0x{flags:02x}"
             )
             return


### PR DESCRIPTION
- Add SwitchEvent packet type (0x07) to IncommingPacketType enum
- Implement _parseSwitchEvent() method to parse switch event packets
- Implement _processSwitchMessage() to handle message types 0x08 and 0x10
- Support button press, release, hold, and release_after_hold events
- Add registerSwitchEventHandler() and unregisterSwitchEventHandler() methods
- Update README with switch event usage example

This adds support for receiving and parsing Casambi switch button events, allowing applications to react to physical button presses from Casambi switches.

This also fixed two issues from my previous PR:
1. It triggered additional events, which I believe were the state broadcast from the entire switch unit. This new PR filters out those events and retains only the actual button event.
2. The button ID was different from the Casambi App. This new code correctly parses them.