### PR TITLE
Expose raw_state and unknown_controls on UnitState

### DIFF
--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -112,6 +112,22 @@ class UnitState:
         self._xy: tuple[float, float] | None = None
         self._slider: int | None = None
         self._onoff: bool | None = None
+        self._raw_state: bytes | None = None
+        self._unknown_controls: list[tuple[int, int, int]] = []
+
+    @property
+    def raw_state(self) -> bytes | None:
+        """Return the raw BLE state bytes last received for this unit, or None if not yet set."""
+        return self._raw_state
+
+    @property
+    def unknown_controls(self) -> list[tuple[int, int, int]]:
+        """Return a copy of the list of unknown controls parsed from the last state update.
+
+        Each entry is a tuple of ``(bit_offset, bit_length, value)`` corresponding to a
+        control whose type is :attr:`UnitControlType.UNKOWN`.
+        """
+        return list(self._unknown_controls)
 
     def _check_range(
         self, value: int | float, min: int | float, max: int | float
@@ -519,6 +535,9 @@ class Unit:
         if not self._state:
             self._state = UnitState()
 
+        self._state._raw_state = value
+        self._state._unknown_controls = []
+
         # TODO: Support for resolutions >8 byte?
         for c in self.unitType.controls:
             # Extract all relevant bytes from the state
@@ -565,6 +584,7 @@ class Unit:
                 _LOGGER.debug(
                     f"Value for unkown control type at {c.offset}: {cInt}. Unit type is {self.unitType.id}."
                 )
+                self._state._unknown_controls.append((c.offset, c.length, cInt))
 
         _LOGGER.debug(f"Parsed {b2a(value)} to {self.state.__repr__()}")
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -462,3 +462,101 @@ def test_unit_serialization_temperature():
     assert unit.state is not None
     assert unit.state.temperature is not None
     assert abs(unit.state.temperature - 4000) < 5
+
+
+def _make_unit(controls: list[UnitControl], state_length: int) -> Unit:
+    """Build a minimal Unit for testing."""
+    ut = UnitType(
+        id=1,
+        model="test",
+        manufacturer="test",
+        mode="test",
+        stateLength=state_length,
+        controls=controls,
+    )
+    return Unit(
+        _typeId=1,
+        deviceId=1,
+        uuid="1",
+        address="1",
+        name="1",
+        firmwareVersion="1",
+        unitType=ut,
+    )
+
+
+def test_unit_state_raw_state() -> None:
+    """raw_state is None initially, then mirrors the bytes passed to setStateFromBytes."""
+    state = UnitState()
+    assert state.raw_state is None
+
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.DIMMER,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(b"\xff")
+    assert unit.state is not None
+    assert unit.state.raw_state == b"\xff"
+
+    # Second call must overwrite, not accumulate.
+    unit.setStateFromBytes(b"\x00")
+    assert unit.state.raw_state == b"\x00"
+
+
+def test_unit_state_unknown_controls() -> None:
+    """unknown_controls captures UNKOWN controls and returns a defensive copy."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(b"\x2a")
+    assert unit.state is not None
+    assert unit.state.unknown_controls == [(0, 8, 0x2A)]
+
+    # Mutating the returned list must not affect internal state.
+    copy = unit.state.unknown_controls
+    copy.clear()
+    assert unit.state.unknown_controls == [(0, 8, 0x2A)]
+
+
+def test_unit_state_unknown_controls_reset() -> None:
+    """unknown_controls is cleared on each setStateFromBytes call (no accumulation)."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(b"\x01")
+    assert unit.state is not None
+    assert len(unit.state.unknown_controls) == 1
+
+    unit.setStateFromBytes(b"\x02")
+    controls = unit.state.unknown_controls
+    assert len(controls) == 1
+    assert controls[0][2] == 0x02


### PR DESCRIPTION
## Problem

Some Casambi devices use proprietary BLE payloads that the library cannot
decode into named controls. Two scenarios arise in practice:

1. **Sensor platforms** (e.g. weather/motion sensors with `EXT/Elements{…}`
   firmware mode) send their measurements as raw bytes inside a `SENSOR`
   control. There is no way to read those bytes through the existing API.

2. **Undocumented controls** produce `UNKOWN`-typed entries whose integer
   values carry useful data (e.g. DALI-2 presence/lux sensors). Those values
   are currently logged and then discarded.

Home-Assistant integrations that want to support these devices have no
choice but to either fork the library or give up.

## Solution

This PR adds two read-only properties to `UnitState` that make the raw data
accessible without changing any existing behaviour:

| Property | Type | Description |
|---|---|---|
| `raw_state` | `bytes \| None` | The raw BLE state bytes last written by `setStateFromBytes`, `None` until first call. |
| `unknown_controls` | `list[tuple[int, int, int]]` | A defensive copy of all `(bit_offset, bit_length, value)` tuples collected from `UNKOWN`-typed controls during the last `setStateFromBytes` call. |

`setStateFromBytes` now stores the incoming bytes and resets
`_unknown_controls` on every call, so both properties always reflect the
most recent state update.

## Design notes

- **Backward compatible** — no existing method signature or return type is
  changed.
- **Defensive copy** — `unknown_controls` returns `list(self._unknown_controls)`
  so external mutation cannot corrupt internal state.
- **`bytes` is immutable** — `raw_state` can safely return the reference
  directly.
- **Reset on each call** — `_unknown_controls` is cleared at the start of
  every `setStateFromBytes` invocation, preventing accumulation across
  multiple updates.

## Tests

Three new test functions are added to `tests/test_unit.py` following the
existing fixture pattern:

- `test_unit_state_raw_state` — verifies initial `None`, correct storage
  after first call, and overwrite on subsequent call.
- `test_unit_state_unknown_controls` — verifies correct tuple content and
  that the returned list is a defensive copy.
- `test_unit_state_unknown_controls_reset` — verifies no accumulation across
  two successive `setStateFromBytes` calls.

All 124 tests pass on Python 3.11–3.14. CI (isort, black, ruff, mypy) is
clean.