### PR TITLE
feat: preserve UNKNOWN controls in partial updates + add setControlValue()

### DIFF
--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -28,7 +28,7 @@ from ._operation import (
     OperationsContextClassic,
     OperationsContextEvolution,
 )
-from ._unit import Group, Scene, Unit, UnitControlType, UnitState
+from ._unit import Group, Scene, Unit, UnitControl, UnitControlType, UnitState
 from .errors import ConnectionStateError
 
 
@@ -240,6 +240,45 @@ class Casambi:
         else:
             stateBytes = target.getStateAsBytes(state)
             await self._send(target, stateBytes, OpCode.SetState)
+
+    async def setControlValue(
+        self, unit: Unit, control: UnitControl, value: int
+    ) -> None:
+        """Set a single control's value and send the updated state.
+
+        The state is built from the unit's current raw state bytes with only
+        the bits described by ``control`` overwritten.  All other controls —
+        including UNKNOWN ones — remain unchanged.
+
+        :param unit: The target unit.
+        :param control: A :class:`UnitControl` from ``unit.unitType.controls``.
+        :param value: Raw integer value to write into the control's bit field.
+        :raises BluetoothError: An error occurred in the bluetooth stack.
+        """
+        if unit.state is not None and unit.state.raw_state is not None:
+            raw = bytearray(unit.state.raw_state)
+        else:
+            raw = bytearray(unit.unitType.stateLength)
+
+        # Clear the target bits then write the new value (little-endian bytes).
+        byte_start = control.offset // 8
+        bit_start = control.offset % 8
+        n_bytes = (control.length + bit_start + 7) // 8
+
+        current = int.from_bytes(
+            raw[byte_start : byte_start + n_bytes], byteorder="little"
+        )
+        mask = ((1 << control.length) - 1) << bit_start
+        current = (current & ~mask) | (
+            (value & ((1 << control.length) - 1)) << bit_start
+        )
+        raw[byte_start : byte_start + n_bytes] = current.to_bytes(
+            n_bytes, byteorder="little"
+        )
+
+        state_bytes = bytes(raw)
+        await self._send(unit, state_bytes, OpCode.SetState)
+        unit.setStateFromBytes(state_bytes)
 
     async def setLevel(self, target: Unit | Group | None, level: int) -> None:
         """Set the level (brightness) for one or multiple units.

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -569,7 +569,11 @@ class Unit:
             else:
                 if c.type == UnitControlType.UNKNOWN and self._state:
                     scaledValue = next(
-                        (v for o, _l, v in self._state._unknown_controls if o == c.offset),
+                        (
+                            v
+                            for o, _l, v in self._state._unknown_controls
+                            if o == c.offset
+                        ),
                         c.default,
                     )
                 else:

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -562,9 +562,18 @@ class Unit:
             elif c.type == UnitControlType.ONOFF and state.onoff is not None:
                 scaledValue = 1 if state.onoff else 0
 
-            # Use default if unsupported type or unset value in state
+            # Use default if unsupported type or unset value in state.
+            # For UNKNOWN controls: preserve the most recently received value
+            # so that a setControlValue() call does not silently reset controls
+            # the caller did not intend to change.
             else:
-                scaledValue = c.default
+                if c.type == UnitControlType.UNKNOWN and self._state:
+                    scaledValue = next(
+                        (v for o, _l, v in self._state._unknown_controls if o == c.offset),
+                        c.default,
+                    )
+                else:
+                    scaledValue = c.default
 
             values.append((c.offset, c.length, scaledValue))
 

--- a/tests/test_casambi.py
+++ b/tests/test_casambi.py
@@ -419,3 +419,80 @@ async def test_disconnect(connected_casambi):
     connected_casambi._casaClient.disconnect.assert_called_once()
     mock_network.disconnect.assert_called_once()
     assert connected_casambi._casaNetwork is None
+
+
+async def test_set_control_value_patches_bits(connected_casambi, mock_unit):
+    """setControlValue sends a packet with only the target bits changed."""
+    control = mock_unit.unitType.controls[0]  # DIMMER, offset=0, length=8
+
+    # Seed the unit with a known raw state
+    mock_unit.setStateFromBytes(b"\xaa")
+
+    await connected_casambi.setControlValue(mock_unit, control, 0x42)
+
+    connected_casambi._casaClient.send.assert_called_once()
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-1] == 0x42
+
+
+async def test_set_control_value_no_state_uses_zeros(connected_casambi, mock_unit):
+    """setControlValue falls back to zero-filled bytes when there is no prior state."""
+    control = mock_unit.unitType.controls[0]  # DIMMER, offset=0, length=8
+    mock_unit._state = None
+
+    await connected_casambi.setControlValue(mock_unit, control, 0x55)
+
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-1] == 0x55
+
+
+async def test_set_control_value_updates_unit_state(connected_casambi, mock_unit):
+    """After setControlValue the unit's state reflects the new value."""
+    control = mock_unit.unitType.controls[0]  # DIMMER, offset=0, length=8
+    mock_unit.setStateFromBytes(b"\x00")
+
+    await connected_casambi.setControlValue(mock_unit, control, 200)
+
+    assert mock_unit.state is not None
+    assert mock_unit.state.dimmer == 200
+
+
+async def test_set_control_value_preserves_other_bytes(connected_casambi):
+    """setControlValue only modifies the target bits; adjacent bytes stay unchanged."""
+    # Build a unit with two 8-bit controls: DIMMER at offset 0, WHITE at offset 8
+    controls = [
+        UnitControl(
+            type=UnitControlType.DIMMER, offset=0, length=8, default=0, readonly=False
+        ),
+        UnitControl(
+            type=UnitControlType.WHITE, offset=8, length=8, default=0, readonly=False
+        ),
+    ]
+    ut = UnitType(
+        id=99,
+        model="test",
+        manufacturer="test",
+        mode="test",
+        stateLength=2,
+        controls=controls,
+    )
+    unit = Unit(
+        _typeId=99,
+        deviceId=99,
+        uuid="x",
+        address="x",
+        name="x",
+        firmwareVersion="1",
+        unitType=ut,
+    )
+    unit.setStateFromBytes(b"\x0a\xc8")  # dimmer=10, white=200
+
+    dimmer_ctrl = controls[0]
+    await connected_casambi.setControlValue(unit, dimmer_ctrl, 0x42)
+
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-2] == 0x42   # dimmer updated
+    assert pkt[-1] == 0xC8   # white unchanged

--- a/tests/test_casambi.py
+++ b/tests/test_casambi.py
@@ -494,5 +494,5 @@ async def test_set_control_value_preserves_other_bytes(connected_casambi):
 
     args, _ = connected_casambi._casaClient.send.call_args
     pkt = args[0]
-    assert pkt[-2] == 0x42   # dimmer updated
-    assert pkt[-1] == 0xC8   # white unchanged
+    assert pkt[-2] == 0x42  # dimmer updated
+    assert pkt[-1] == 0xC8  # white unchanged

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -560,3 +560,47 @@ def test_unit_state_unknown_controls_reset() -> None:
     controls = unit.state.unknown_controls
     assert len(controls) == 1
     assert controls[0][2] == 0x02
+
+
+def test_getStateAsBytes_preserves_unknown_control_current_value() -> None:
+    """getStateAsBytes re-uses the last received value for UNKNOWN controls."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.UNKNOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    # Seed the unit with a known raw state — this stores value 0x2A in unknown_controls.
+    unit.setStateFromBytes(b"\x2a")
+
+    # Calling getStateAsBytes with an empty UnitState should NOT revert to default (0).
+    state = UnitState()
+    data = unit.getStateAsBytes(state)
+    assert data == b"\x2a"
+
+
+def test_getStateAsBytes_uses_default_when_no_state() -> None:
+    """getStateAsBytes falls back to control.default when there is no prior state."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.UNKNOWN,
+                offset=0,
+                length=8,
+                default=0xBE,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+    # No setStateFromBytes called — _state is None.
+    state = UnitState()
+    data = unit.getStateAsBytes(state)
+    assert data == bytes([0xBE])


### PR DESCRIPTION
## Problem

\`setUnitState()\` silently resets UNKNOWN controls to their default value whenever
a partial state is sent (e.g. changing only brightness). For vendor-specific devices
that rely on UNKNOWN controls to hold configuration bits, this corrupts the device
state on every normal state change.

There is also no way to update a single control's bits precisely without touching
the rest of the state byte array.

## Solution

**1. Preserve UNKNOWN controls in \`getStateAsBytes()\`**

When building the byte array to send, UNKNOWN controls now fall back to their most
recently received raw value (from \`unit.state.unknown_controls\`, added in #48)
instead of blindly using \`c.default\`. The device's current configuration is preserved
across every \`setUnitState()\` call.

**2. New \`setControlValue()\` method**

A new async method on \`Casambi\` that reads the unit's current \`raw_state\`, overwrites
only the bits described by a single \`UnitControl\`, and sends the result. All other
controls — including UNKNOWN ones — remain byte-exact from the last received state.

Builds on \`raw_state\` and \`unknown_controls\` exposed in #48.

## Design notes

- **Backward compatible** — \`setUnitState()\` behaviour is unchanged for known controls; the UNKNOWN fallback only activates when a prior state exists.
- **Builds on #48** — uses \`raw_state\` as the authoritative source for bit-level writes.
- **Exports \`UnitControl\`** — required for callers of \`setControlValue()\`.

## Tests

- \`test_unit.py\`: UNKNOWN control preservation with and without prior state
- \`test_casambi.py\`: \`setControlValue()\` bit manipulation, correct bytes sent, state updated, adjacent bytes preserved

All 152 tests pass. Linters clean (black, isort, ruff, mypy).