### PR TITLE
feat: sensor platform support (element_names, UnitState.sensors, Unit.sensor_cache)

### DIFF
--- a/src/CasambiBt/_network.py
+++ b/src/CasambiBt/_network.py
@@ -365,7 +365,7 @@ class Network:
                 self._logger.warning(
                     f"Unsupported control mode {typeStr} in fixture {id}."
                 )
-                type = UnitControlType.UNKOWN
+                type = UnitControlType.UNIMPLEMENTED
 
             controlObj = UnitControl(
                 type,

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 class _DeprecatingMeta(EnumMeta):
     """EnumMeta subclass that emits a DeprecationWarning for the UNKOWN typo alias."""
 
-    def __getattr__(cls, name: str):
+    def __getattr__(cls, name: str) -> "UnitControlType":
         if name == "UNKOWN":
             warnings.warn(
                 "UnitControlType.UNKOWN is a typo and deprecated — use UNKNOWN instead. "
@@ -21,7 +21,7 @@ class _DeprecatingMeta(EnumMeta):
                 stacklevel=2,
             )
             return cls.UNKNOWN
-        return super().__getattr__(name)
+        raise AttributeError(f"'{cls.__name__}' has no attribute '{name}'")
 
 
 # Numbers are totally arbitrary so far.

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -1,7 +1,7 @@
 import logging
 from binascii import b2a_hex as b2a
 from colorsys import hsv_to_rgb, rgb_to_hsv
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, unique
 from typing import Final
 
@@ -96,6 +96,19 @@ class UnitType:
 
         return None
 
+    @property
+    def element_names(self) -> list[str]:
+        """Return element names parsed from the mode string, e.g. ``["Presence", "Daylight"]``.
+
+        Parses names from the ``{Name1,Name2,...}`` section of the mode string.
+        Returns an empty list for modes without this pattern.
+        """
+        start = self.mode.find("{")
+        end = self.mode.find("}")
+        if start == -1 or end == -1 or end <= start + 1:
+            return []
+        return [name.strip() for name in self.mode[start + 1 : end].split(",")]
+
 
 # TODO: Support for different resolutions?
 # TODO: Work with HS instead of RGB internally
@@ -114,6 +127,7 @@ class UnitState:
         self._onoff: bool | None = None
         self._raw_state: bytes | None = None
         self._unknown_controls: list[tuple[int, int, int]] = []
+        self._sensors: dict[str, int] = {}
 
     @property
     def raw_state(self) -> bytes | None:
@@ -128,6 +142,16 @@ class UnitState:
         control whose type is :attr:`UnitControlType.UNKOWN`.
         """
         return list(self._unknown_controls)
+
+    @property
+    def sensors(self) -> dict[str, int]:
+        """Return sensor readings keyed by element name from the unit type mode string.
+
+        Populated for units whose mode string contains a ``{Name1,Name2,...}`` pattern
+        and whose unrecognised (UNKOWN) controls map to those names in order.
+        Returns a copy; empty for all other unit types.
+        """
+        return dict(self._sensors)
 
     def _check_range(
         self, value: int | float, min: int | float, max: int | float
@@ -437,6 +461,7 @@ class Unit:
     _on: bool = False
     _online: bool = False
     _isClassic: bool = False
+    _sensor_cache: dict[int, int] = field(default_factory=dict)
 
     @property
     def state(self) -> UnitState | None:
@@ -458,6 +483,17 @@ class Unit:
     @property
     def online(self) -> bool:
         return self._online
+
+    @property
+    def sensor_cache(self) -> dict[int, int]:
+        """Return accumulated sensor readings for EXT/Elements multiplexed sensor platforms.
+
+        Each entry maps a ``packet_type`` (encoded in ``raw[1] >> 6``) to the most
+        recently received raw value for that sensor.  The mapping from ``packet_type``
+        to physical measurement is device-specific and remains the responsibility of the
+        caller.  Returns an empty dict for non-EXT/Elements unit types.
+        """
+        return dict(self._sensor_cache)
 
     # TODO: Add tests for this method
     def getStateAsBytes(self, state: UnitState) -> bytes:
@@ -537,6 +573,7 @@ class Unit:
 
         self._state._raw_state = value
         self._state._unknown_controls = []
+        self._state._sensors = {}
 
         # TODO: Support for resolutions >8 byte?
         for c in self.unitType.controls:
@@ -579,12 +616,32 @@ class Unit:
                 self._state.slider = cInt << scale
             elif c.type == UnitControlType.ONOFF:
                 self._state.onoff = cInt != 0
+            elif c.type == UnitControlType.SENSOR:
+                _LOGGER.debug(
+                    f"Sensor control at {c.offset}: {cInt}. Unit type is {self.unitType.id}."
+                )
             elif c.type == UnitControlType.UNKOWN:
                 # Might be useful for implementing more state types
                 _LOGGER.debug(
                     f"Value for unkown control type at {c.offset}: {cInt}. Unit type is {self.unitType.id}."
                 )
+                unkown_index = len(self._state._unknown_controls)
                 self._state._unknown_controls.append((c.offset, c.length, cInt))
+                names = self.unitType.element_names
+                if unkown_index < len(names):
+                    self._state._sensors[names[unkown_index]] = cInt
+
+        # For EXT/Elements multiplexed sensor platforms, decode the packet header
+        # and accumulate per-type readings in sensor_cache across successive packets.
+        # Each 5-byte packet reports one sensor: raw[1] bits[7:6] = packet_type,
+        # raw[2] = raw value.
+        if len(value) >= 3 and self.unitType.mode.startswith("EXT/Elements"):
+            packet_type = (value[1] >> 6) & 0x03
+            sensor_value = value[2]
+            self._sensor_cache[packet_type] = sensor_value
+            _LOGGER.debug(
+                f"EXT/Elements sensor update: packet_type={packet_type}, value={sensor_value}"
+            )
 
         _LOGGER.debug(f"Parsed {b2a(value)} to {self.state.__repr__()}")
 

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -1,16 +1,32 @@
 import logging
+import warnings
 from binascii import b2a_hex as b2a
 from colorsys import hsv_to_rgb, rgb_to_hsv
 from dataclasses import dataclass, field
-from enum import Enum, unique
+from enum import Enum, EnumMeta, unique
 from typing import Final
 
 _LOGGER = logging.getLogger(__name__)
 
 
+class _DeprecatingMeta(EnumMeta):
+    """EnumMeta subclass that emits a DeprecationWarning for the UNKOWN typo alias."""
+
+    def __getattr__(cls, name: str):
+        if name == "UNKOWN":
+            warnings.warn(
+                "UnitControlType.UNKOWN is a typo and deprecated — use UNKNOWN instead. "
+                "Will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return cls.UNKNOWN
+        return super().__getattr__(name)
+
+
 # Numbers are totally arbitrary so far.
 @unique
-class UnitControlType(Enum):
+class UnitControlType(Enum, metaclass=_DeprecatingMeta):
     """All implemented control types."""
 
     DIMMER = 0
@@ -43,8 +59,11 @@ class UnitControlType(Enum):
     SENSOR = 9
     """A sensor value of the light."""
 
-    UNKOWN = 99
-    """State isn't implemented. Control saved for debuggin purposes."""
+    UNIMPLEMENTED = 98
+    """Control type exists in the protocol but is not yet implemented in this library."""
+
+    UNKNOWN = 99
+    """Control type is explicitly unknown in the protocol (e.g. used for sensor data)."""
 
 
 @unique
@@ -139,7 +158,7 @@ class UnitState:
         """Return a copy of the list of unknown controls parsed from the last state update.
 
         Each entry is a tuple of ``(bit_offset, bit_length, value)`` corresponding to a
-        control whose type is :attr:`UnitControlType.UNKOWN`.
+        control whose type is :attr:`UnitControlType.UNKNOWN`.
         """
         return list(self._unknown_controls)
 
@@ -148,7 +167,7 @@ class UnitState:
         """Return sensor readings keyed by element name from the unit type mode string.
 
         Populated for units whose mode string contains a ``{Name1,Name2,...}`` pattern
-        and whose unrecognised (UNKOWN) controls map to those names in order.
+        and whose unrecognised (UNKNOWN) controls map to those names in order.
         Returns a copy; empty for all other unit types.
         """
         return dict(self._sensors)
@@ -620,16 +639,16 @@ class Unit:
                 _LOGGER.debug(
                     f"Sensor control at {c.offset}: {cInt}. Unit type is {self.unitType.id}."
                 )
-            elif c.type == UnitControlType.UNKOWN:
+            elif c.type == UnitControlType.UNKNOWN:
                 # Might be useful for implementing more state types
                 _LOGGER.debug(
-                    f"Value for unkown control type at {c.offset}: {cInt}. Unit type is {self.unitType.id}."
+                    f"Value for unknown control type at {c.offset}: {cInt}. Unit type is {self.unitType.id}."
                 )
-                unkown_index = len(self._state._unknown_controls)
+                unknown_index = len(self._state._unknown_controls)
                 self._state._unknown_controls.append((c.offset, c.length, cInt))
                 names = self.unitType.element_names
-                if unkown_index < len(names):
-                    self._state._sensors[names[unkown_index]] = cInt
+                if unknown_index < len(names):
+                    self._state._sensors[names[unknown_index]] = cInt
 
         # For EXT/Elements multiplexed sensor platforms, decode the packet header
         # and accumulate per-type readings in sensor_cache across successive packets.

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -348,7 +348,9 @@ def test_unkown_alias_emits_deprecation_warning() -> None:
     """Accessing UNKOWN raises DeprecationWarning and returns the UNKNOWN member."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        alias = UnitControlType.UNKOWN  # noqa: F841 — intentionally testing deprecated access
+        alias = (
+            UnitControlType.UNKOWN
+        )  # noqa: F841 — intentionally testing deprecated access
     assert len(caught) == 1
     assert issubclass(caught[0].category, DeprecationWarning)
     assert "UNKOWN" in str(caught[0].message)

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -1,0 +1,339 @@
+"""Tests for sensor platform support: element_names, UnitState.sensors, Unit.sensor_cache."""
+
+from CasambiBt._unit import Unit, UnitControl, UnitControlType, UnitType
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_unit(
+    controls: list[UnitControl],
+    state_length: int,
+    mode: str = "test",
+) -> Unit:
+    """Build a minimal Unit for testing."""
+    ut = UnitType(
+        id=1,
+        model="test",
+        manufacturer="test",
+        mode=mode,
+        stateLength=state_length,
+        controls=controls,
+    )
+    return Unit(
+        _typeId=1,
+        deviceId=1,
+        uuid="test-uuid",
+        address="00:00:00:00:00:01",
+        name="test",
+        firmwareVersion="1.0",
+        unitType=ut,
+    )
+
+
+# ── UnitType.element_names ─────────────────────────────────────────────────────
+
+
+def test_element_names_dali_sensor() -> None:
+    """DALI Sensor mode with two element names."""
+    ut = UnitType(
+        id=1,
+        model="m",
+        manufacturer="v",
+        mode="DALI Sensor{Presence,Daylight}",
+        stateLength=2,
+        controls=[],
+    )
+    assert ut.element_names == ["Presence", "Daylight"]
+
+
+def test_element_names_ext_elements() -> None:
+    """EXT/Elements mode with two element names."""
+    ut = UnitType(
+        id=1,
+        model="m",
+        manufacturer="v",
+        mode="EXT/Elements{Presence,Daylight}",
+        stateLength=5,
+        controls=[],
+    )
+    assert ut.element_names == ["Presence", "Daylight"]
+
+
+def test_element_names_single() -> None:
+    """Mode with a single element name."""
+    ut = UnitType(
+        id=1,
+        model="m",
+        manufacturer="v",
+        mode="DALI Sensor{Motion}",
+        stateLength=1,
+        controls=[],
+    )
+    assert ut.element_names == ["Motion"]
+
+
+def test_element_names_strips_whitespace() -> None:
+    """Whitespace around names is stripped."""
+    ut = UnitType(
+        id=1,
+        model="m",
+        manufacturer="v",
+        mode="DALI Sensor{ Presence , Daylight }",
+        stateLength=2,
+        controls=[],
+    )
+    assert ut.element_names == ["Presence", "Daylight"]
+
+
+def test_element_names_no_braces() -> None:
+    """Regular modes without braces return an empty list."""
+    for mode in ("PWM/Dim", "EXT/1ch/Dim", "Kinetic Switch", "Sensor"):
+        ut = UnitType(
+            id=1, model="m", manufacturer="v", mode=mode, stateLength=1, controls=[]
+        )
+        assert ut.element_names == [], f"Expected [] for mode {mode!r}"
+
+
+def test_element_names_empty_braces() -> None:
+    """Empty braces return an empty list."""
+    ut = UnitType(
+        id=1,
+        model="m",
+        manufacturer="v",
+        mode="DALI Sensor{}",
+        stateLength=1,
+        controls=[],
+    )
+    assert ut.element_names == []
+
+
+# ── UnitState.sensors (DALI-2 style: UNKOWN controls + element names) ──────────
+
+
+def test_sensors_populated_from_unkown_controls() -> None:
+    """UNKOWN controls are keyed by element name when mode has element_names."""
+    # Simulate DALI-2: 2 UNKOWN controls at offsets 0 and 2 (2 bits presence + 12 bits lux)
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=2,
+                default=0,
+                readonly=True,
+            ),
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=2,
+                length=12,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=2,
+        mode="DALI Sensor{Presence,Daylight}",
+    )
+    # Encode: presence=1 (bits 0-1), lux=512 (bits 2-13)
+    # 1 in bits[1:0], 512 in bits[13:2]
+    # 512 << 2 = 2048 = 0x0800
+    # combined: 0x0800 | 0x01 = 0x0801 → little-endian bytes: 0x01, 0x08
+    unit.setStateFromBytes(b"\x01\x08")
+    assert unit.state is not None
+    assert unit.state.sensors == {"Presence": 1, "Daylight": 512}
+
+
+def test_sensors_partial_names() -> None:
+    """Only UNKOWN controls with a corresponding element name get a key; extras go to unknown_controls only."""
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=8,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=2,
+        mode="DALI Sensor{OnlyOne}",  # only 1 name, 2 controls
+    )
+    unit.setStateFromBytes(b"\x0a\x0b")
+    assert unit.state is not None
+    assert unit.state.sensors == {"OnlyOne": 0x0A}
+    assert len(unit.state.unknown_controls) == 2
+
+
+def test_sensors_empty_without_element_names() -> None:
+    """No element names in mode → sensors dict is always empty."""
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=1,
+        mode="PWM/Dim",
+    )
+    unit.setStateFromBytes(b"\xff")
+    assert unit.state is not None
+    assert unit.state.sensors == {}
+    # unknown_controls still populated as before
+    assert unit.state.unknown_controls == [(0, 8, 0xFF)]
+
+
+def test_sensors_reset_each_call() -> None:
+    """sensors dict is cleared on each setStateFromBytes call (no accumulation)."""
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=1,
+        mode="DALI Sensor{Presence}",
+    )
+    unit.setStateFromBytes(b"\x01")
+    assert unit.state is not None
+    assert unit.state.sensors == {"Presence": 1}
+
+    unit.setStateFromBytes(b"\x00")
+    assert unit.state.sensors == {"Presence": 0}
+
+
+def test_sensors_returns_copy() -> None:
+    """Mutating the returned dict does not affect internal state."""
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.UNKOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=1,
+        mode="DALI Sensor{Presence}",
+    )
+    unit.setStateFromBytes(b"\x01")
+    copy = unit.state.sensors  # type: ignore[union-attr]
+    copy["Presence"] = 99
+    assert unit.state.sensors == {"Presence": 1}  # type: ignore[union-attr]
+
+
+# ── Unit.sensor_cache (EXT/Elements multiplexed protocol) ──────────────────────
+
+
+def _ext_elements_unit() -> Unit:
+    """Build an EXT/Elements unit with SENSOR controls (simplified: 1 control)."""
+    return _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.SENSOR,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=5,
+        mode="EXT/Elements{Presence,Daylight}",
+    )
+
+
+def test_sensor_cache_initially_empty() -> None:
+    """sensor_cache is empty before any state update."""
+    unit = _ext_elements_unit()
+    assert unit.sensor_cache == {}
+
+
+def test_sensor_cache_accumulates_across_packets() -> None:
+    """Successive packets with different packet_types all accumulate in sensor_cache."""
+    unit = _ext_elements_unit()
+
+    # packet_type=0 (rain): raw[1] bits[7:6]=00 → raw[1]=0x00, raw[2]=1
+    unit.setStateFromBytes(b"\x04\x00\x01\x00\x3c")
+    assert unit.sensor_cache == {0: 1}
+
+    # packet_type=1 (wind): raw[1] bits[7:6]=01 → raw[1]=0x40, raw[2]=12
+    unit.setStateFromBytes(b"\x04\x40\x0c\x00\x3c")
+    assert unit.sensor_cache == {0: 1, 1: 12}
+
+    # packet_type=2 (solar): raw[1] bits[7:6]=10 → raw[1]=0x80, raw[2]=68
+    unit.setStateFromBytes(b"\x04\x80\x44\x00\x3c")
+    assert unit.sensor_cache == {0: 1, 1: 12, 2: 68}
+
+    # packet_type=3 (PIR): raw[1] bits[7:6]=11 → raw[1]=0xC0, raw[2]=0
+    unit.setStateFromBytes(b"\x04\xc0\x00\x00\x3c")
+    assert unit.sensor_cache == {0: 1, 1: 12, 2: 68, 3: 0}
+
+
+def test_sensor_cache_updates_existing_key() -> None:
+    """A new packet for the same packet_type overwrites the previous value."""
+    unit = _ext_elements_unit()
+
+    unit.setStateFromBytes(b"\x04\x00\x01\x00\x3c")  # rain = 1
+    unit.setStateFromBytes(b"\x04\x00\x05\x00\x3c")  # rain = 5
+    assert unit.sensor_cache[0] == 5
+
+
+def test_sensor_cache_not_reset_between_calls() -> None:
+    """sensor_cache persists across calls; only updated entries change."""
+    unit = _ext_elements_unit()
+
+    unit.setStateFromBytes(b"\x04\x00\x01\x00\x3c")  # packet_type=0
+    unit.setStateFromBytes(b"\x04\x40\x0c\x00\x3c")  # packet_type=1
+
+    # Both keys must still be present after two distinct packets
+    assert 0 in unit.sensor_cache
+    assert 1 in unit.sensor_cache
+
+
+def test_sensor_cache_only_for_ext_elements() -> None:
+    """sensor_cache is not populated for non-EXT/Elements modes."""
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.SENSOR,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=5,
+        mode="DALI Sensor{Presence,Daylight}",
+    )
+    unit.setStateFromBytes(b"\x04\x40\x0c\x00\x3c")
+    assert unit.sensor_cache == {}
+
+
+def test_sensor_cache_ignores_short_packets() -> None:
+    """Packets shorter than 3 bytes do not update the cache."""
+    unit = _ext_elements_unit()
+    unit.setStateFromBytes(b"\x04\x40")  # only 2 bytes
+    assert unit.sensor_cache == {}
+
+
+def test_sensor_cache_returns_copy() -> None:
+    """Mutating the returned dict does not affect internal state."""
+    unit = _ext_elements_unit()
+    unit.setStateFromBytes(b"\x04\x00\x01\x00\x3c")
+    copy = unit.sensor_cache
+    copy[0] = 99
+    assert unit.sensor_cache[0] == 1

--- a/tests/test_sensor_platform.py
+++ b/tests/test_sensor_platform.py
@@ -1,5 +1,7 @@
 """Tests for sensor platform support: element_names, UnitState.sensors, Unit.sensor_cache."""
 
+import warnings
+
 from CasambiBt._unit import Unit, UnitControl, UnitControlType, UnitType
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -107,23 +109,23 @@ def test_element_names_empty_braces() -> None:
     assert ut.element_names == []
 
 
-# ── UnitState.sensors (DALI-2 style: UNKOWN controls + element names) ──────────
+# ── UnitState.sensors (DALI-2 style: UNKNOWN controls + element names) ─────────
 
 
-def test_sensors_populated_from_unkown_controls() -> None:
-    """UNKOWN controls are keyed by element name when mode has element_names."""
+def test_sensors_populated_from_unknown_controls() -> None:
+    """UNKNOWN controls are keyed by element name when mode has element_names."""
     # Simulate DALI-2: 2 UNKOWN controls at offsets 0 and 2 (2 bits presence + 12 bits lux)
     unit = _make_unit(
         controls=[
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=0,
                 length=2,
                 default=0,
                 readonly=True,
             ),
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=2,
                 length=12,
                 default=0,
@@ -143,18 +145,18 @@ def test_sensors_populated_from_unkown_controls() -> None:
 
 
 def test_sensors_partial_names() -> None:
-    """Only UNKOWN controls with a corresponding element name get a key; extras go to unknown_controls only."""
+    """Only UNKNOWN controls with a corresponding element name get a key; extras go to unknown_controls only."""
     unit = _make_unit(
         controls=[
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=0,
                 length=8,
                 default=0,
                 readonly=True,
             ),
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=8,
                 length=8,
                 default=0,
@@ -175,7 +177,7 @@ def test_sensors_empty_without_element_names() -> None:
     unit = _make_unit(
         controls=[
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=0,
                 length=8,
                 default=0,
@@ -197,7 +199,7 @@ def test_sensors_reset_each_call() -> None:
     unit = _make_unit(
         controls=[
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=0,
                 length=8,
                 default=0,
@@ -220,7 +222,7 @@ def test_sensors_returns_copy() -> None:
     unit = _make_unit(
         controls=[
             UnitControl(
-                type=UnitControlType.UNKOWN,
+                type=UnitControlType.UNKNOWN,
                 offset=0,
                 length=8,
                 default=0,
@@ -337,3 +339,48 @@ def test_sensor_cache_returns_copy() -> None:
     copy = unit.sensor_cache
     copy[0] = 99
     assert unit.sensor_cache[0] == 1
+
+
+# ── UnitControlType.UNKOWN deprecation + UNIMPLEMENTED distinction ──────────────
+
+
+def test_unkown_alias_emits_deprecation_warning() -> None:
+    """Accessing UNKOWN raises DeprecationWarning and returns the UNKNOWN member."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        alias = UnitControlType.UNKOWN  # noqa: F841 — intentionally testing deprecated access
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "UNKOWN" in str(caught[0].message)
+    assert alias is UnitControlType.UNKNOWN
+
+
+def test_unimplemented_not_in_unknown_controls() -> None:
+    """UNIMPLEMENTED controls are NOT included in unknown_controls or sensors."""
+    unit = _make_unit(
+        controls=[
+            UnitControl(
+                type=UnitControlType.UNIMPLEMENTED,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+            UnitControl(
+                type=UnitControlType.UNKNOWN,
+                offset=8,
+                length=8,
+                default=0,
+                readonly=True,
+            ),
+        ],
+        state_length=2,
+        mode="DALI Sensor{Sensor1}",
+    )
+    unit.setStateFromBytes(b"\x0a\x0b")
+    assert unit.state is not None
+    # Only the UNKNOWN control appears in unknown_controls
+    assert len(unit.state.unknown_controls) == 1
+    assert unit.state.unknown_controls[0] == (8, 8, 0x0B)
+    # And sensors only maps the UNKNOWN control
+    assert unit.state.sensors == {"Sensor1": 0x0B}


### PR DESCRIPTION
## Problem

Some Casambi units act as sensor platforms — they report environmental data
(presence, daylight, temperature…) rather than controllable state. The library
currently has no way to expose this data in a typed, named form.

Two distinct patterns exist in the wild:

- **DALI-2 style**: the unit's mode string contains `{Name1,Name2,...}` and the corresponding UNKOWN controls hold the sensor values in order.
- **EXT/Elements multiplexed**: successive state packets each carry one sensor reading, identified by bits in the packet header (`raw[1] >> 6`). A single `setStateFromBytes()` call never contains the full picture — accumulation is needed.

## Solution

Three additive properties on existing classes:

**`UnitType.element_names -> list[str]`**
Parses the `{Name1,Name2,...}` section from the mode string. Returns `[]` for modes without this pattern.

**`UnitState.sensors -> dict[str, int]`**
Populated during `setStateFromBytes()`: zips `element_names` with the UNKOWN controls in order. Gives callers a named view of sensor readings without any knowledge of bit offsets. Builds on `unknown_controls` from #48.

**`Unit.sensor_cache -> dict[int, int]`**
Accumulates readings across successive packets for EXT/Elements units. Key is the packet type (0–3 from `raw[1] >> 6`), value is the latest raw reading. The mapping from packet type to physical measurement remains the caller's responsibility (device-specific).

## Design notes

- **Non-breaking** — all three are new read-only properties; no existing API changes.
- **Builds on #48** — `sensors` uses `unknown_controls` as its data source.
- **Minimal footprint** — no new parsing loop; `sensors` and `sensor_cache` are populated as a side-effect of the existing `setStateFromBytes()` walk.

## Tests

New file `tests/test_sensor_platform.py`:
- `element_names` parsing (with/without pattern, malformed)
- `sensors` dict population and ordering
- `sensor_cache` accumulation across multiple packets

All existing tests pass. CI clean.