### PR TITLE
fix: migrate naive datetimes when loading pickle cache

### DIFF
--- a/src/CasambiBt/_network.py
+++ b/src/CasambiBt/_network.py
@@ -72,6 +72,9 @@ class Network:
             if await (cachePath / SESSION_CACHE_FILE).exists():
                 sessionData = await (cachePath / SESSION_CACHE_FILE).read_bytes()
                 self._session = pickle.loads(sessionData)
+                # Migrate naive datetime from caches created before UTC-aware datetimes
+                if self._session.expires.tzinfo is None:
+                    self._session.expires = self._session.expires.replace(tzinfo=UTC)
                 self._logger.info("Session loaded.")
 
     async def _saveSesion(self) -> None:
@@ -86,6 +89,11 @@ class Network:
             if await (cachePath / TYPES_CACHE_FILE).exists():
                 typeData = await (cachePath / TYPES_CACHE_FILE).read_bytes()
                 self._unitTypes = pickle.loads(typeData)
+                # Migrate naive datetimes from caches created before UTC-aware datetimes
+                self._unitTypes = {
+                    k: (t, dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt)
+                    for k, (t, dt) in self._unitTypes.items()
+                }
                 self._logger.info("Unit type cache loaded.")
 
     async def _saveTypeCache(self) -> None:


### PR DESCRIPTION
## Summary

Commit `011ad97` switched `_network.py` to use `datetime.now(UTC)` (UTC-aware datetimes) but did not migrate existing pickle caches (`session.pck`, `types.pck`). Any user upgrading from a pre-`011ad97` installation crashes on every reconnect with:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

This fix adds a one-time migration in `_loadSession` and `_loadTypeCache`: after deserializing the pickle, naive datetimes are converted to UTC-aware in-place before any comparison is made.

## Changes

- `_loadSession`: patch `_session.expires` if `tzinfo is None`
- `_loadTypeCache`: rebuild `_unitTypes` dict replacing naive `dt` values with UTC-aware equivalents

## Test plan

- [ ] Install a version prior to `011ad97`, let it run once (creates `session.pck` / `types.pck` with naive datetimes)
- [ ] Upgrade to this fix — confirm no `TypeError` on restart
- [ ] Fresh install (no cache) — confirm normal startup, no regression