### PR TITLE
feat: add UnitControlType.WHITECOLORBALANCE and Casambi.setWhiteColorBalance()

### DIFF
--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -280,6 +280,30 @@ class Casambi:
         await self._send(unit, state_bytes, OpCode.SetState)
         unit.setStateFromBytes(state_bytes)
 
+    async def setWhiteColorBalance(self, unit: Unit, value: int) -> None:
+        """Set the white/color balance for a unit with a WHITECOLORBALANCE control.
+
+        ``value`` is the raw 6-bit cross-fade level in the range [0, 63].
+        0 = pure white channel, 63 = pure color channel.
+
+        The balance is written via :meth:`setControlValue` which manipulates the
+        raw state bytes in-place and sends a ``SetState`` opcode, so all other
+        controls (brightness, colour, temperature) are preserved.
+
+        :param unit: The target unit.  Must have a ``WHITECOLORBALANCE`` control.
+        :param value: Raw balance level in range [0, 63].
+        :raises ValueError: The unit does not support ``WHITECOLORBALANCE``, or value out of range.
+        :raises BluetoothError: An error occurred in the bluetooth stack.
+        """
+        if value < 0 or value > 63:
+            raise ValueError(
+                f"White/color balance value {value} is not in range [0, 63]."
+            )
+        control = unit.unitType.get_control(UnitControlType.WHITECOLORBALANCE)
+        if control is None:
+            raise ValueError("The unit does not support WHITECOLORBALANCE.")
+        await self.setControlValue(unit, control, value)
+
     async def setLevel(self, target: Unit | Group | None, level: int) -> None:
         """Set the level (brightness) for one or multiple units.
 

--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -28,7 +28,7 @@ from ._operation import (
     OperationsContextClassic,
     OperationsContextEvolution,
 )
-from ._unit import Group, Scene, Unit, UnitControlType, UnitState
+from ._unit import Group, Scene, Unit, UnitControl, UnitControlType, UnitState
 from .errors import ConnectionStateError
 
 
@@ -240,6 +240,45 @@ class Casambi:
         else:
             stateBytes = target.getStateAsBytes(state)
             await self._send(target, stateBytes, OpCode.SetState)
+
+    async def setControlValue(
+        self, unit: Unit, control: UnitControl, value: int
+    ) -> None:
+        """Set a single control's value and send the updated state.
+
+        The state is built from the unit's current raw state bytes with only
+        the bits described by ``control`` overwritten.  All other controls —
+        including UNKNOWN ones — remain unchanged.
+
+        :param unit: The target unit.
+        :param control: A :class:`UnitControl` from ``unit.unitType.controls``.
+        :param value: Raw integer value to write into the control's bit field.
+        :raises BluetoothError: An error occurred in the bluetooth stack.
+        """
+        if unit.state is not None and unit.state.raw_state is not None:
+            raw = bytearray(unit.state.raw_state)
+        else:
+            raw = bytearray(unit.unitType.stateLength)
+
+        # Clear the target bits then write the new value (little-endian bytes).
+        byte_start = control.offset // 8
+        bit_start = control.offset % 8
+        n_bytes = (control.length + bit_start + 7) // 8
+
+        current = int.from_bytes(
+            raw[byte_start : byte_start + n_bytes], byteorder="little"
+        )
+        mask = ((1 << control.length) - 1) << bit_start
+        current = (current & ~mask) | (
+            (value & ((1 << control.length) - 1)) << bit_start
+        )
+        raw[byte_start : byte_start + n_bytes] = current.to_bytes(
+            n_bytes, byteorder="little"
+        )
+
+        state_bytes = bytes(raw)
+        await self._send(unit, state_bytes, OpCode.SetState)
+        unit.setStateFromBytes(state_bytes)
 
     async def setLevel(self, target: Unit | Group | None, level: int) -> None:
         """Set the level (brightness) for one or multiple units.

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -59,6 +59,10 @@ class UnitControlType(Enum, metaclass=_DeprecatingMeta):
     SENSOR = 9
     """A sensor value of the light."""
 
+    WHITECOLORBALANCE = 10
+    """Cross-fade balance between the white and color channels (raw 6-bit value,
+    0 = pure white, 63 = pure color)."""
+
     UNIMPLEMENTED = 98
     """Control type exists in the protocol but is not yet implemented in this library."""
 
@@ -144,6 +148,7 @@ class UnitState:
         self._xy: tuple[float, float] | None = None
         self._slider: int | None = None
         self._onoff: bool | None = None
+        self._white_balance: int | None = None
         self._raw_state: bytes | None = None
         self._unknown_controls: list[tuple[int, int, int]] = []
         self._sensors: dict[str, int] = {}
@@ -340,6 +345,23 @@ class UnitState:
     @onoff.deleter
     def onoff(self) -> None:
         self._onoff = None
+
+    WCB_MIN: Final = 0
+    WCB_MAX: Final = 63
+
+    @property
+    def white_balance(self) -> int | None:
+        """Return the white/color balance raw value (0 = pure white, 63 = pure color), or None."""
+        return self._white_balance
+
+    @white_balance.setter
+    def white_balance(self, value: int) -> None:
+        self._check_range(value, self.WCB_MIN, self.WCB_MAX)
+        self._white_balance = value
+
+    @white_balance.deleter
+    def white_balance(self) -> None:
+        self._white_balance = None
 
     def __repr__(self) -> str:
         return f"UnitState(dimmer={self.dimmer}, vertical={self.vertical}, rgb={self.rgb.__repr__()}, white={self.white}, temperature={self.temperature}, colorsource={self.colorsource}, xy={self.xy}, slider={self.slider}, onoff={self.onoff})"
@@ -561,11 +583,18 @@ class Unit:
                 scaledValue = state.slider >> scale
             elif c.type == UnitControlType.ONOFF and state.onoff is not None:
                 scaledValue = 1 if state.onoff else 0
+            elif (
+                c.type == UnitControlType.WHITECOLORBALANCE
+                and state.white_balance is not None
+            ):
+                scaledValue = state.white_balance
 
             # Use default if unsupported type or unset value in state.
             # For UNKNOWN controls: preserve the most recently received value
             # so that a setControlValue() call does not silently reset controls
             # the caller did not intend to change.
+            # For WHITECOLORBALANCE: preserve the last received value so that
+            # brightness / colour changes do not reset the balance.
             else:
                 if c.type == UnitControlType.UNKNOWN and self._state:
                     scaledValue = next(
@@ -576,6 +605,12 @@ class Unit:
                         ),
                         c.default,
                     )
+                elif (
+                    c.type == UnitControlType.WHITECOLORBALANCE
+                    and self._state
+                    and self._state.white_balance is not None
+                ):
+                    scaledValue = self._state.white_balance
                 else:
                     scaledValue = c.default
 
@@ -648,6 +683,8 @@ class Unit:
                 self._state.slider = cInt << scale
             elif c.type == UnitControlType.ONOFF:
                 self._state.onoff = cInt != 0
+            elif c.type == UnitControlType.WHITECOLORBALANCE:
+                self._state.white_balance = cInt
             elif c.type == UnitControlType.SENSOR:
                 _LOGGER.debug(
                     f"Sensor control at {c.offset}: {cInt}. Unit type is {self.unitType.id}."

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -569,7 +569,11 @@ class Unit:
             else:
                 if c.type == UnitControlType.UNKNOWN and self._state:
                     scaledValue = next(
-                        (v for o, _l, v in self._state._unknown_controls if o == c.offset),
+                        (
+                            v
+                            for o, _l, v in self._state._unknown_controls
+                            if o == c.offset
+                        ),
                         c.default,
                     )
                 else:

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -562,9 +562,18 @@ class Unit:
             elif c.type == UnitControlType.ONOFF and state.onoff is not None:
                 scaledValue = 1 if state.onoff else 0
 
-            # Use default if unsupported type or unset value in state
+            # Use default if unsupported type or unset value in state.
+            # For UNKNOWN controls: preserve the most recently received value
+            # so that a setControlValue() call does not silently reset controls
+            # the caller did not intend to change.
             else:
-                scaledValue = c.default
+                if c.type == UnitControlType.UNKNOWN and self._state:
+                    scaledValue = next(
+                        (v for o, _l, v in self._state._unknown_controls if o == c.offset),
+                        c.default,
+                    )
+                else:
+                    scaledValue = c.default
 
             values.append((c.offset, c.length, scaledValue))
 

--- a/tests/test_casambi.py
+++ b/tests/test_casambi.py
@@ -85,6 +85,35 @@ def mock_xy_unit():
 
 
 @pytest.fixture
+def mock_wcb_unit():
+    control = UnitControl(
+        type=UnitControlType.WHITECOLORBALANCE,
+        offset=0,
+        length=6,
+        default=0,
+        readonly=False,
+    )
+    unit_type = UnitType(
+        id=3,
+        model="Model",
+        manufacturer="Casambi",
+        mode="Mode",
+        stateLength=1,
+        controls=[control],
+    )
+    unit = Unit(
+        _typeId=3,
+        deviceId=12,
+        uuid="uuid3",
+        address="addr3",
+        name="Unit 3",
+        firmwareVersion="1.0",
+        unitType=unit_type,
+    )
+    return unit
+
+
+@pytest.fixture
 def mock_group(mock_unit):
     return Group(groudId=20, name="Group 1", units=[mock_unit])
 
@@ -496,3 +525,30 @@ async def test_set_control_value_preserves_other_bytes(connected_casambi):
     pkt = args[0]
     assert pkt[-2] == 0x42  # dimmer updated
     assert pkt[-1] == 0xC8  # white unchanged
+
+
+async def test_set_white_color_balance_valid(connected_casambi, mock_wcb_unit):
+    """setWhiteColorBalance sends the correct raw value in the packet."""
+    connected_casambi._casaNetwork.units.append(mock_wcb_unit)
+    mock_wcb_unit.setStateFromBytes(b"\x00")
+
+    await connected_casambi.setWhiteColorBalance(mock_wcb_unit, 42)
+
+    connected_casambi._casaClient.send.assert_called_once()
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-1] & 0x3F == 42
+
+
+async def test_set_white_color_balance_invalid_range(connected_casambi, mock_wcb_unit):
+    """setWhiteColorBalance raises ValueError for out-of-range values."""
+    with pytest.raises(ValueError):
+        await connected_casambi.setWhiteColorBalance(mock_wcb_unit, -1)
+    with pytest.raises(ValueError):
+        await connected_casambi.setWhiteColorBalance(mock_wcb_unit, 64)
+
+
+async def test_set_white_color_balance_unsupported_unit(connected_casambi, mock_unit):
+    """setWhiteColorBalance raises ValueError when the unit has no WCB control."""
+    with pytest.raises(ValueError):
+        await connected_casambi.setWhiteColorBalance(mock_unit, 10)

--- a/tests/test_casambi.py
+++ b/tests/test_casambi.py
@@ -419,3 +419,80 @@ async def test_disconnect(connected_casambi):
     connected_casambi._casaClient.disconnect.assert_called_once()
     mock_network.disconnect.assert_called_once()
     assert connected_casambi._casaNetwork is None
+
+
+async def test_set_control_value_patches_bits(connected_casambi, mock_unit):
+    """setControlValue sends a packet with only the target bits changed."""
+    control = mock_unit.unitType.controls[0]  # DIMMER, offset=0, length=8
+
+    # Seed the unit with a known raw state
+    mock_unit.setStateFromBytes(b"\xaa")
+
+    await connected_casambi.setControlValue(mock_unit, control, 0x42)
+
+    connected_casambi._casaClient.send.assert_called_once()
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-1] == 0x42
+
+
+async def test_set_control_value_no_state_uses_zeros(connected_casambi, mock_unit):
+    """setControlValue falls back to zero-filled bytes when there is no prior state."""
+    control = mock_unit.unitType.controls[0]  # DIMMER, offset=0, length=8
+    mock_unit._state = None
+
+    await connected_casambi.setControlValue(mock_unit, control, 0x55)
+
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-1] == 0x55
+
+
+async def test_set_control_value_updates_unit_state(connected_casambi, mock_unit):
+    """After setControlValue the unit's state reflects the new value."""
+    control = mock_unit.unitType.controls[0]  # DIMMER, offset=0, length=8
+    mock_unit.setStateFromBytes(b"\x00")
+
+    await connected_casambi.setControlValue(mock_unit, control, 200)
+
+    assert mock_unit.state is not None
+    assert mock_unit.state.dimmer == 200
+
+
+async def test_set_control_value_preserves_other_bytes(connected_casambi):
+    """setControlValue only modifies the target bits; adjacent bytes stay unchanged."""
+    # Build a unit with two 8-bit controls: DIMMER at offset 0, WHITE at offset 8
+    controls = [
+        UnitControl(
+            type=UnitControlType.DIMMER, offset=0, length=8, default=0, readonly=False
+        ),
+        UnitControl(
+            type=UnitControlType.WHITE, offset=8, length=8, default=0, readonly=False
+        ),
+    ]
+    ut = UnitType(
+        id=99,
+        model="test",
+        manufacturer="test",
+        mode="test",
+        stateLength=2,
+        controls=controls,
+    )
+    unit = Unit(
+        _typeId=99,
+        deviceId=99,
+        uuid="x",
+        address="x",
+        name="x",
+        firmwareVersion="1",
+        unitType=ut,
+    )
+    unit.setStateFromBytes(b"\x0a\xc8")  # dimmer=10, white=200
+
+    dimmer_ctrl = controls[0]
+    await connected_casambi.setControlValue(unit, dimmer_ctrl, 0x42)
+
+    args, _ = connected_casambi._casaClient.send.call_args
+    pkt = args[0]
+    assert pkt[-2] == 0x42   # dimmer updated
+    assert pkt[-1] == 0xC8   # white unchanged

--- a/tests/test_casambi.py
+++ b/tests/test_casambi.py
@@ -494,5 +494,5 @@ async def test_set_control_value_preserves_other_bytes(connected_casambi):
 
     args, _ = connected_casambi._casaClient.send.call_args
     pkt = args[0]
-    assert pkt[-2] == 0x42   # dimmer updated
-    assert pkt[-1] == 0xC8   # white unchanged
+    assert pkt[-2] == 0x42  # dimmer updated
+    assert pkt[-1] == 0xC8  # white unchanged

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -604,3 +604,155 @@ def test_getStateAsBytes_uses_default_when_no_state() -> None:
     state = UnitState()
     data = unit.getStateAsBytes(state)
     assert data == bytes([0xBE])
+
+
+# ---------------------------------------------------------------------------
+# WHITECOLORBALANCE tests
+# ---------------------------------------------------------------------------
+
+
+def test_unit_state_white_balance() -> None:
+    """white_balance range validation and del."""
+    state = UnitState()
+    assert state.white_balance is None
+
+    state.white_balance = 0
+    assert state.white_balance == 0
+
+    state.white_balance = 63
+    assert state.white_balance == 63
+
+    with pytest.raises(ValueError):
+        state.white_balance = -1
+
+    with pytest.raises(ValueError):
+        state.white_balance = 64
+
+    del state.white_balance
+    assert state.white_balance is None
+
+
+def test_setStateFromBytes_decodes_white_color_balance() -> None:
+    """setStateFromBytes populates white_balance for WHITECOLORBALANCE controls."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.WHITECOLORBALANCE,
+                offset=0,
+                length=6,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(bytes([0x2A]))  # 0x2A = 42
+    assert unit.state is not None
+    assert unit.state.white_balance == 42
+
+
+def test_setStateFromBytes_resets_white_balance_on_each_call() -> None:
+    """white_balance is overwritten, not accumulated, on repeated calls."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.WHITECOLORBALANCE,
+                offset=0,
+                length=6,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(bytes([10]))
+    unit.setStateFromBytes(bytes([20]))
+    assert unit.state is not None
+    assert unit.state.white_balance == 20
+
+
+def test_getStateAsBytes_writes_white_color_balance() -> None:
+    """getStateAsBytes encodes white_balance into the correct bits."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.WHITECOLORBALANCE,
+                offset=0,
+                length=6,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    state = UnitState()
+    state.white_balance = 42
+    data = unit.getStateAsBytes(state)
+    assert data[0] & 0x3F == 42  # lower 6 bits
+
+
+def test_getStateAsBytes_preserves_white_balance_when_not_in_new_state() -> None:
+    """white_balance from the last received state is preserved when not set in the new UnitState."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.WHITECOLORBALANCE,
+                offset=0,
+                length=6,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(bytes([31]))  # seed white_balance = 31
+
+    # New state does not set white_balance → should preserve 31
+    state = UnitState()
+    data = unit.getStateAsBytes(state)
+    assert data[0] & 0x3F == 31
+
+
+def test_getStateAsBytes_uses_wcb_default_when_no_current_state() -> None:
+    """Falls back to control.default when there is no prior state."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.WHITECOLORBALANCE,
+                offset=0,
+                length=6,
+                default=10,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    # No setStateFromBytes called
+    state = UnitState()
+    data = unit.getStateAsBytes(state)
+    assert data[0] & 0x3F == 10
+
+
+def test_white_color_balance_not_in_unknown_controls() -> None:
+    """WHITECOLORBALANCE values must not appear in unknown_controls."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.WHITECOLORBALANCE,
+                offset=0,
+                length=6,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    unit.setStateFromBytes(bytes([42]))
+    assert unit.state is not None
+    assert unit.state.unknown_controls == []

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -560,3 +560,47 @@ def test_unit_state_unknown_controls_reset() -> None:
     controls = unit.state.unknown_controls
     assert len(controls) == 1
     assert controls[0][2] == 0x02
+
+
+def test_getStateAsBytes_preserves_unknown_control_current_value() -> None:
+    """getStateAsBytes re-uses the last received value for UNKNOWN controls."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.UNKNOWN,
+                offset=0,
+                length=8,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    # Seed the unit with a known raw state — this stores value 0x2A in unknown_controls.
+    unit.setStateFromBytes(b"\x2a")
+
+    # Calling getStateAsBytes with an empty UnitState should NOT revert to default (0).
+    state = UnitState()
+    data = unit.getStateAsBytes(state)
+    assert data == b"\x2a"
+
+
+def test_getStateAsBytes_uses_default_when_no_state() -> None:
+    """getStateAsBytes falls back to control.default when there is no prior state."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.UNKNOWN,
+                offset=0,
+                length=8,
+                default=0xBE,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+    # No setStateFromBytes called — _state is None.
+    state = UnitState()
+    data = unit.getStateAsBytes(state)
+    assert data == bytes([0xBE])


### PR DESCRIPTION
## Summary

The Casambi API exposes a `"whitecolorbalance"` control on PWM RGB+TW devices that cross-fades between the white and color channels. Previously this string resolved to `UNIMPLEMENTED (98)` and was invisible to callers.

**Depends on #52** (`setControlValue()` + `raw_state`) which must be merged first.

## Changes

- **`UnitControlType.WHITECOLORBALANCE = 10`**: the API string `"whitecolorbalance"` now resolves directly via `UnitControlType["WHITECOLORBALANCE"]`.
- **`UnitState.white_balance`** property: raw 6-bit value in `[0, 63]` (0 = pure white, 63 = pure color) with range validation.
- **`setStateFromBytes()`**: decodes `WHITECOLORBALANCE` bits into `state.white_balance`.
- **`getStateAsBytes()`**: encodes `white_balance` when set; **preserves** the last received value when the new `UnitState` leaves `white_balance` unset, so that brightness or colour changes do not silently reset the balance.
- **`Casambi.setWhiteColorBalance(unit, value)`**: validates the range [0, 63] and delegates to `setControlValue()` to patch the raw bytes in-place.

## Tests

- `test_unit.py`: 7 tests — property validation, decode, no-accumulation, encode, preservation, default fallback, no bleed into `unknown_controls`.
- `test_casambi.py`: `mock_wcb_unit` fixture + 3 tests for `setWhiteColorBalance()`.

162 tests pass. Linters clean (black, isort, ruff, mypy).