### PR TITLE
feat: add UnitControlType.PRESENCE and LUX; graceful fallback for unknown types

### DIFF
--- a/src/CasambiBt/_network.py
+++ b/src/CasambiBt/_network.py
@@ -365,7 +365,7 @@ class Network:
                 self._logger.warning(
                     f"Unsupported control mode {typeStr} in fixture {id}."
                 )
-                type = UnitControlType.UNIMPLEMENTED
+                type = UnitControlType.UNKNOWN
 
             controlObj = UnitControl(
                 type,

--- a/src/CasambiBt/_unit.py
+++ b/src/CasambiBt/_unit.py
@@ -59,6 +59,12 @@ class UnitControlType(Enum, metaclass=_DeprecatingMeta):
     SENSOR = 9
     """A sensor value of the light."""
 
+    PRESENCE = 11
+    """Binary presence/occupancy value (0 = absent, ≥1 = present). Raw 2-bit integer."""
+
+    LUX = 12
+    """Illuminance in lux. Raw 12-bit integer (0–4095)."""
+
     UNIMPLEMENTED = 98
     """Control type exists in the protocol but is not yet implemented in this library."""
 
@@ -144,6 +150,8 @@ class UnitState:
         self._xy: tuple[float, float] | None = None
         self._slider: int | None = None
         self._onoff: bool | None = None
+        self._presence: int | None = None
+        self._lux: int | None = None
         self._raw_state: bytes | None = None
         self._unknown_controls: list[tuple[int, int, int]] = []
         self._sensors: dict[str, int] = {}
@@ -340,6 +348,40 @@ class UnitState:
     @onoff.deleter
     def onoff(self) -> None:
         self._onoff = None
+
+    PRESENCE_MIN: Final = 0
+    PRESENCE_MAX: Final = 3
+
+    @property
+    def presence(self) -> int | None:
+        """Return presence/occupancy raw value (0 = absent, ≥1 = present), or None."""
+        return self._presence
+
+    @presence.setter
+    def presence(self, value: int) -> None:
+        self._check_range(value, self.PRESENCE_MIN, self.PRESENCE_MAX)
+        self._presence = value
+
+    @presence.deleter
+    def presence(self) -> None:
+        self._presence = None
+
+    LUX_MIN: Final = 0
+    LUX_MAX: Final = 4095
+
+    @property
+    def lux(self) -> int | None:
+        """Return illuminance in lux (raw 12-bit value, 0–4095), or None."""
+        return self._lux
+
+    @lux.setter
+    def lux(self, value: int) -> None:
+        self._check_range(value, self.LUX_MIN, self.LUX_MAX)
+        self._lux = value
+
+    @lux.deleter
+    def lux(self) -> None:
+        self._lux = None
 
     def __repr__(self) -> str:
         return f"UnitState(dimmer={self.dimmer}, vertical={self.vertical}, rgb={self.rgb.__repr__()}, white={self.white}, temperature={self.temperature}, colorsource={self.colorsource}, xy={self.xy}, slider={self.slider}, onoff={self.onoff})"
@@ -561,6 +603,10 @@ class Unit:
                 scaledValue = state.slider >> scale
             elif c.type == UnitControlType.ONOFF and state.onoff is not None:
                 scaledValue = 1 if state.onoff else 0
+            elif c.type == UnitControlType.PRESENCE and state.presence is not None:
+                scaledValue = state.presence
+            elif c.type == UnitControlType.LUX and state.lux is not None:
+                scaledValue = state.lux
 
             # Use default if unsupported type or unset value in state
             else:
@@ -635,6 +681,10 @@ class Unit:
                 self._state.slider = cInt << scale
             elif c.type == UnitControlType.ONOFF:
                 self._state.onoff = cInt != 0
+            elif c.type == UnitControlType.PRESENCE:
+                self._state.presence = cInt
+            elif c.type == UnitControlType.LUX:
+                self._state.lux = cInt
             elif c.type == UnitControlType.SENSOR:
                 _LOGGER.debug(
                     f"Sensor control at {c.offset}: {cInt}. Unit type is {self.unitType.id}."

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -560,3 +560,147 @@ def test_unit_state_unknown_controls_reset() -> None:
     controls = unit.state.unknown_controls
     assert len(controls) == 1
     assert controls[0][2] == 0x02
+
+
+def test_unit_state_presence() -> None:
+    """presence property stores values in [0, 3] and rejects out-of-range."""
+    state = UnitState()
+    assert state.presence is None
+
+    state.presence = 0
+    assert state.presence == 0
+
+    state.presence = 1
+    assert state.presence == 1
+
+    state.presence = 3
+    assert state.presence == 3
+
+    with pytest.raises(ValueError):
+        state.presence = -1
+
+    with pytest.raises(ValueError):
+        state.presence = 4
+
+    del state.presence
+    assert state.presence is None
+
+
+def test_unit_state_lux() -> None:
+    """lux property stores values in [0, 4095] and rejects out-of-range."""
+    state = UnitState()
+    assert state.lux is None
+
+    state.lux = 0
+    assert state.lux == 0
+
+    state.lux = 2048
+    assert state.lux == 2048
+
+    state.lux = 4095
+    assert state.lux == 4095
+
+    with pytest.raises(ValueError):
+        state.lux = -1
+
+    with pytest.raises(ValueError):
+        state.lux = 4096
+
+    del state.lux
+    assert state.lux is None
+
+
+def test_setStateFromBytes_decodes_presence() -> None:
+    """PRESENCE control is decoded correctly into UnitState.presence."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.PRESENCE,
+                offset=0,
+                length=2,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    # 0b01 in bits [1:0] → presence = 1 (present)
+    unit.setStateFromBytes(b"\x01")
+    assert unit.state is not None
+    assert unit.state.presence == 1
+
+    # 0b00 → absent
+    unit.setStateFromBytes(b"\x00")
+    assert unit.state.presence == 0
+
+
+def test_setStateFromBytes_decodes_lux() -> None:
+    """LUX control is decoded correctly into UnitState.lux."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.LUX,
+                offset=0,
+                length=12,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=2,
+    )
+
+    # 500 lux, little-endian 12-bit in 2 bytes: 500 = 0x1F4 → bytes 0xF4 0x01
+    unit.setStateFromBytes(b"\xf4\x01")
+    assert unit.state is not None
+    assert unit.state.lux == 500
+
+    unit.setStateFromBytes(b"\x00\x00")
+    assert unit.state.lux == 0
+
+
+def test_getStateAsBytes_encodes_presence() -> None:
+    """PRESENCE control is encoded correctly from UnitState.presence."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.PRESENCE,
+                offset=0,
+                length=2,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=1,
+    )
+
+    state = UnitState()
+    state.presence = 1
+    data = unit.getStateAsBytes(state)
+    assert data[0] & 0x03 == 1
+
+    state.presence = 0
+    data = unit.getStateAsBytes(state)
+    assert data[0] & 0x03 == 0
+
+
+def test_getStateAsBytes_encodes_lux() -> None:
+    """LUX control is encoded correctly from UnitState.lux."""
+    unit = _make_unit(
+        [
+            UnitControl(
+                type=UnitControlType.LUX,
+                offset=0,
+                length=12,
+                default=0,
+                readonly=False,
+            )
+        ],
+        state_length=2,
+    )
+
+    state = UnitState()
+    state.lux = 500
+    data = unit.getStateAsBytes(state)
+    val = int.from_bytes(data[:2], byteorder="little") & 0xFFF
+    assert val == 500


### PR DESCRIPTION
## Problem

The Casambi API returns controls with types `"PRESENCE"` and `"LUX"` for DALI
Sensor fixtures. These are not in `UnitControlType`, so the `_network.py` parser
falls back to `UNIMPLEMENTED` and `setStateFromBytes()` silently ignores them.
Result: occupancy and illuminance sensors are permanently unavailable in integrations
that rely on `UnitState.presence` / `UnitState.lux`.

## Solution

- Add `UnitControlType.PRESENCE = 11` (2-bit occupancy, 0 = absent, ≥1 = present)
- Add `UnitControlType.LUX = 12` (12-bit illuminance, 0–4095 lux)
- Add typed `UnitState.presence` and `UnitState.lux` properties with range validation
- Decode/encode branches in `setStateFromBytes()` / `getStateAsBytes()`
- Change fallback for unrecognised types from `UNIMPLEMENTED` to `UNKNOWN`
  (graceful degradation — unrecognised controls end up in `unknown_controls` instead
  of being silently dropped)

## Cache note

Users with an existing `types.pck` cache will keep stale `UNIMPLEMENTED` mappings
for `PRESENCE`/`LUX` until the cache is cleared. PR #59 (cache versioning) handles
this automatically — recommend merging #59 before or alongside this PR.

## Tests

6 new tests covering: property validation, range clamping, 2-bit presence
encode/decode, 12-bit lux encode/decode.

## Related PRs

- #59 — cache versioning (recommended prerequisite for transparent cache invalidation)
- #52 — partial state update (modifies same methods; merge order matters)
- #58 — WHITECOLORBALANCE (same pattern as this PR)