### PR TITLE
feat: version the unit type cache to auto-invalidate on schema changes

### DIFF
--- a/src/CasambiBt/_network.py
+++ b/src/CasambiBt/_network.py
@@ -22,6 +22,13 @@ from .errors import (
 SESSION_CACHE_FILE: Final = "session.pck"
 TYPES_CACHE_FILE: Final = "types.pck"
 
+# Increment this whenever UnitType, UnitControl, or UnitControlType change in
+# a way that makes previously-pickled objects incompatible or incorrect.
+# On mismatch the types cache is discarded and all fixtures are re-fetched from
+# the Casambi API.  History:
+#   1 — initial versioned cache
+TYPES_CACHE_VERSION: Final = 1
+
 
 @dataclass()
 class _NetworkSession:
@@ -83,15 +90,38 @@ class Network:
     async def _loadTypeCache(self) -> None:
         self._logger.debug("Loading unit type cache...")
         async with self._cache as cachePath:
-            if await (cachePath / TYPES_CACHE_FILE).exists():
-                typeData = await (cachePath / TYPES_CACHE_FILE).read_bytes()
-                self._unitTypes = pickle.loads(typeData)
-                self._logger.info("Unit type cache loaded.")
+            cacheFile = cachePath / TYPES_CACHE_FILE
+            if await cacheFile.exists():
+                typeData = await cacheFile.read_bytes()
+                payload = pickle.loads(typeData)
+
+                # Versioned cache: payload is (version, dict).
+                # Unversioned legacy caches are plain dicts — treat as version 0.
+                if isinstance(payload, tuple) and len(payload) == 2:
+                    cached_version, unitTypes = payload
+                else:
+                    cached_version, unitTypes = 0, payload
+
+                if cached_version != TYPES_CACHE_VERSION:
+                    self._logger.warning(
+                        "Unit type cache version %d is outdated (expected %d). "
+                        "Discarding cache — fixtures will be re-fetched from the API.",
+                        cached_version,
+                        TYPES_CACHE_VERSION,
+                    )
+                    self._unitTypes = {}
+                    return
+
+                self._unitTypes = unitTypes
+                self._logger.info(
+                    "Unit type cache loaded (version %d).", cached_version
+                )
 
     async def _saveTypeCache(self) -> None:
         self._logger.debug("Saving type cache...")
         async with self._cache as cachePath:
-            typeData = pickle.dumps(self._unitTypes)
+            payload = (TYPES_CACHE_VERSION, self._unitTypes)
+            typeData = pickle.dumps(payload)
             await (cachePath / TYPES_CACHE_FILE).write_bytes(typeData)
 
     async def getNetworkId(self, forceOffline: bool = False) -> None:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,6 +14,7 @@ from CasambiBt._cache import Cache
 from CasambiBt._network import (
     SESSION_CACHE_FILE,
     TYPES_CACHE_FILE,
+    TYPES_CACHE_VERSION,
     Network,
     _NetworkSession,
 )
@@ -278,13 +279,62 @@ async def test_load_session_and_types(network: Network, cache: Cache):
 
     async with cache as cache_path:
         await (cache_path / SESSION_CACHE_FILE).write_bytes(pickle.dumps(session))
-        await (cache_path / TYPES_CACHE_FILE).write_bytes(pickle.dumps(unit_types))
+        await (cache_path / TYPES_CACHE_FILE).write_bytes(
+            pickle.dumps((TYPES_CACHE_VERSION, unit_types))
+        )
 
     await network._loadSession()
     await network._loadTypeCache()
 
     assert network._session is not None
     assert network._session.session == "token"
+    assert network._unitTypes == unit_types
+
+
+async def test_load_type_cache_correct_version(network: Network, cache: Cache):
+    """Test that a correctly versioned cache is accepted."""
+    unit_types = {42: (None, datetime.now(UTC))}
+    async with cache as cache_path:
+        await (cache_path / TYPES_CACHE_FILE).write_bytes(
+            pickle.dumps((TYPES_CACHE_VERSION, unit_types))
+        )
+
+    await network._loadTypeCache()
+    assert network._unitTypes == unit_types
+
+
+async def test_load_type_cache_outdated_version(network: Network, cache: Cache):
+    """Test that an outdated cache version is discarded."""
+    unit_types = {99: (None, datetime.now(UTC))}
+    async with cache as cache_path:
+        await (cache_path / TYPES_CACHE_FILE).write_bytes(
+            pickle.dumps((TYPES_CACHE_VERSION - 1, unit_types))
+        )
+
+    await network._loadTypeCache()
+    assert network._unitTypes == {}
+
+
+async def test_load_type_cache_legacy_unversioned(network: Network, cache: Cache):
+    """Test that a legacy plain-dict cache (no version tuple) is discarded."""
+    unit_types = {7: (None, datetime.now(UTC))}
+    async with cache as cache_path:
+        # Write a legacy payload — plain dict, no version wrapper
+        await (cache_path / TYPES_CACHE_FILE).write_bytes(pickle.dumps(unit_types))
+
+    await network._loadTypeCache()
+    assert network._unitTypes == {}
+
+
+async def test_save_and_reload_type_cache(network: Network, cache: Cache):
+    """Test that the type cache save/reload roundtrip preserves data."""
+    unit_types = {5: (None, datetime.now(UTC))}
+    network._unitTypes = unit_types
+
+    await network._saveTypeCache()
+    network._unitTypes = {}
+    await network._loadTypeCache()
+
     assert network._unitTypes == unit_types
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -18,6 +18,7 @@ from CasambiBt._network import (
     Network,
     _NetworkSession,
 )
+from CasambiBt._unit import UnitType
 from CasambiBt.errors import (
     AuthenticationError,
     NetworkNotFoundError,
@@ -275,7 +276,9 @@ async def test_load_session_and_types(network: Network, cache: Cache):
         keyID=1,
         expires=datetime.now(UTC) + timedelta(days=1),
     )
-    unit_types = {1: (None, datetime.now(UTC))}
+    unit_types: dict[int, tuple[UnitType | None, datetime]] = {
+        1: (None, datetime.now(UTC))
+    }
 
     async with cache as cache_path:
         await (cache_path / SESSION_CACHE_FILE).write_bytes(pickle.dumps(session))
@@ -293,7 +296,9 @@ async def test_load_session_and_types(network: Network, cache: Cache):
 
 async def test_load_type_cache_correct_version(network: Network, cache: Cache):
     """Test that a correctly versioned cache is accepted."""
-    unit_types = {42: (None, datetime.now(UTC))}
+    unit_types: dict[int, tuple[UnitType | None, datetime]] = {
+        42: (None, datetime.now(UTC))
+    }
     async with cache as cache_path:
         await (cache_path / TYPES_CACHE_FILE).write_bytes(
             pickle.dumps((TYPES_CACHE_VERSION, unit_types))
@@ -305,7 +310,9 @@ async def test_load_type_cache_correct_version(network: Network, cache: Cache):
 
 async def test_load_type_cache_outdated_version(network: Network, cache: Cache):
     """Test that an outdated cache version is discarded."""
-    unit_types = {99: (None, datetime.now(UTC))}
+    unit_types: dict[int, tuple[UnitType | None, datetime]] = {
+        99: (None, datetime.now(UTC))
+    }
     async with cache as cache_path:
         await (cache_path / TYPES_CACHE_FILE).write_bytes(
             pickle.dumps((TYPES_CACHE_VERSION - 1, unit_types))
@@ -317,7 +324,9 @@ async def test_load_type_cache_outdated_version(network: Network, cache: Cache):
 
 async def test_load_type_cache_legacy_unversioned(network: Network, cache: Cache):
     """Test that a legacy plain-dict cache (no version tuple) is discarded."""
-    unit_types = {7: (None, datetime.now(UTC))}
+    unit_types: dict[int, tuple[UnitType | None, datetime]] = {
+        7: (None, datetime.now(UTC))
+    }
     async with cache as cache_path:
         # Write a legacy payload — plain dict, no version wrapper
         await (cache_path / TYPES_CACHE_FILE).write_bytes(pickle.dumps(unit_types))
@@ -328,7 +337,9 @@ async def test_load_type_cache_legacy_unversioned(network: Network, cache: Cache
 
 async def test_save_and_reload_type_cache(network: Network, cache: Cache):
     """Test that the type cache save/reload roundtrip preserves data."""
-    unit_types = {5: (None, datetime.now(UTC))}
+    unit_types: dict[int, tuple[UnitType | None, datetime]] = {
+        5: (None, datetime.now(UTC))
+    }
     network._unitTypes = unit_types
 
     await network._saveTypeCache()


### PR DESCRIPTION
## Problem

The `types.pck` cache stores pickled `UnitType` / `UnitControl` objects. When
the library is updated and control types change (e.g. a value that was `UNIMPLEMENTED`
is now a named type), the old pickle continues to be loaded — the API is never
re-queried and the stale mapping persists until the cache file is manually deleted.

## Solution

Version the payload. The cache file now stores `(TYPES_CACHE_VERSION, dict)`
instead of a plain dict. On load:

- **Correct version** → use as before.
- **Outdated version** (or legacy plain dict, treated as version 0) → discard,
  log a `WARNING`, and let the normal update path re-fetch all fixtures from the
  Casambi API.

`TYPES_CACHE_VERSION` starts at **1**. Future commits should increment it
whenever `UnitType`, `UnitControl`, or `UnitControlType` change in a
backward-incompatible way.

## Changes

- `_network.py`: add `TYPES_CACHE_VERSION: Final = 1`
- `_loadTypeCache()`: detect versioned vs legacy payload; discard on mismatch
- `_saveTypeCache()`: wrap payload in `(TYPES_CACHE_VERSION, dict)`

## Tests

- Fix `test_load_session_and_types` to write a versioned payload.
- Add 4 new tests: correct version accepted, outdated discarded, legacy plain-dict discarded, save/reload roundtrip.

150 tests pass. Linters clean (black, isort, ruff, mypy).