### PR TITLE
feat: decode switch events via INVOCATION frame format with retransmit dedup

### DIFF
--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -475,7 +475,7 @@ class Casambi:
     def _dataCallback(
         self, packetType: IncomingPacketType, data: dict[str, Any] | SwitchEvent
     ) -> None:
-        self._logger.debug(f"Incomming data callback of type {str(packetType)}")
+        self._logger.debug(f"Incoming data callback of type {str(packetType)}")
         if packetType == IncomingPacketType.UnitState:
             unitData = cast(dict[str, Any], data)
             self._logger.debug(
@@ -550,13 +550,13 @@ class Casambi:
         """Register a new handler for switch events.
 
         This handler is called whenever a switch event is received.
-        The handler is supplied with a dictionary containing:
+        The handler is supplied with a SwitchEvent containing:
         - unit_id: The ID of the switch unit
-        - button: The button number that was pressed/released
-        - event: Either "button_press" or "button_release"
-        - message_type: The raw message type (0x08 or 0x10)
-        - flags: Additional flags from the message
-        - extra_data: Any additional data from the message
+        - button: The button number (1-based, = button_event_index + 1)
+        - button_event_index: 0-based index from the protocol
+        - event: A ButtonEventType (PRESS, RELEASE, HOLD, RELEASE_AFTER_HOLD)
+        - flags: Frame flags
+        - extra_data: Any additional payload bytes
 
         :param handler: The method to call when a switch event is received.
         """

--- a/src/CasambiBt/_client.py
+++ b/src/CasambiBt/_client.py
@@ -74,7 +74,7 @@ class CasambiClient(ABC):
             else address_or_device
         )
         self._logger = logging.getLogger(__name__)
-        self._switch_decoder = SwitchEventDecoder(self._logger)
+        self._switch_decoder = SwitchEventDecoder()
         self._connectionState: ConnectionState = ConnectionState.NONE
         self._dataCallback = dataCallback
         self._disconnectedCallback = disonnectedCallback
@@ -543,7 +543,7 @@ class CasambiClientEvolution(CasambiClient):
             # In the future we might want to parse the revision and issue a warning if there is a mismatch.
             pass
         else:
-            self._logger.info(f"Packet type {packetType} not implemented. Ignoring!")
+            self._logger.debug(f"Packet type {packetType} not implemented. Ignoring!")
 
     def _parseUnitStates(self, data: bytes) -> None:
         self._logger.debug("Parsing incoming unit states...")

--- a/src/CasambiBt/_client.py
+++ b/src/CasambiBt/_client.py
@@ -20,7 +20,7 @@ from bleak_retry_connector import (
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from CasambiBt._switch import parseSwitchEvents
+from CasambiBt._switch import SwitchEventDecoder
 
 from ._constants import (
     CASA_AUTH_CHAR_UUID,
@@ -74,6 +74,7 @@ class CasambiClient(ABC):
             else address_or_device
         )
         self._logger = logging.getLogger(__name__)
+        self._switch_decoder = SwitchEventDecoder(self._logger)
         self._connectionState: ConnectionState = ConnectionState.NONE
         self._dataCallback = dataCallback
         self._disconnectedCallback = disonnectedCallback
@@ -250,6 +251,7 @@ class CasambiClient(ABC):
                 self._logger.debug("Failed to disconnect BleakClient.", exc_info=True)
 
         self._connectionState = ConnectionState.NONE
+        self._switch_decoder.reset()
         self._logger.info("Disconnected.")
 
 
@@ -530,7 +532,9 @@ class CasambiClientEvolution(CasambiClient):
         if packetType == IncomingPacketType.UnitState:
             self._parseUnitStates(packetContents[1:])
         elif packetType == IncomingPacketType.SwitchEvent:
-            for s in parseSwitchEvents(packetContents[1:], self._inPacketCount):
+            for s in self._switch_decoder.decode(
+                packetContents[1:], self._inPacketCount
+            ):
                 self._dataCallback(IncomingPacketType.SwitchEvent, s)
         elif packetType == IncomingPacketType.NetworkConfig:
             # We don't care about the config the network thinks it has.
@@ -539,9 +543,10 @@ class CasambiClientEvolution(CasambiClient):
             # In the future we might want to parse the revision and issue a warning if there is a mismatch.
             pass
         else:
-            self._logger.debug(f"Packet type {packetType} not implemented. Ignoring!")
+            self._logger.info(f"Packet type {packetType} not implemented. Ignoring!")
 
     def _parseUnitStates(self, data: bytes) -> None:
+        self._logger.debug("Parsing incoming unit states...")
         self._logger.debug(f"Incoming unit state: {b2a(data)}")
 
         pos = 0

--- a/src/CasambiBt/_invocation.py
+++ b/src/CasambiBt/_invocation.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class InvocationFrame:
+    """One INVOCATION frame from a decrypted type-7 packet.
+
+    Ground truth: casambi-android `v1.C1775b.Q(Q2.h)` parses:
+    - flags:u16 (big-endian)
+    - opcode:u8
+    - origin:u16
+    - target:u16
+    - age:u16
+    - origin_handle?:u8 (if flags & 0x0200)
+    - payload: (flags & 0x3f) bytes
+    """
+
+    flags: int
+    opcode: int
+    origin: int
+    target: int
+    age: int
+    origin_handle: int | None
+    payload: bytes
+    offset: int  # start offset of this frame in the decrypted type-7 payload
+
+    @property
+    def payload_len(self) -> int:
+        return self.flags & 0x3F
+
+
+_FLAG_HAS_ORIGIN_HANDLE: Final[int] = 0x0200
+
+
+def parse_invocation_stream(
+    data: bytes, *, logger: logging.Logger | None = None
+) -> list[InvocationFrame]:
+    """Parse decrypted packet type-7 payload into INVOCATION frames."""
+
+    frames: list[InvocationFrame] = []
+    pos = 0
+
+    while len(data) - pos >= 9:
+        frame_offset = pos
+
+        flags = int.from_bytes(data[pos : pos + 2], "big")
+        pos += 2
+
+        opcode = data[pos]
+        pos += 1
+
+        origin = int.from_bytes(data[pos : pos + 2], "big")
+        pos += 2
+
+        target = int.from_bytes(data[pos : pos + 2], "big")
+        pos += 2
+
+        age = int.from_bytes(data[pos : pos + 2], "big")
+        pos += 2
+
+        origin_handle: int | None = None
+        if flags & _FLAG_HAS_ORIGIN_HANDLE:
+            if pos >= len(data):
+                if logger:
+                    logger.debug(
+                        "INVOCATION frame truncated at origin_handle (offset=%d flags=0x%04x).",
+                        frame_offset,
+                        flags,
+                    )
+                break
+            origin_handle = data[pos]
+            pos += 1
+
+        payload_len = flags & 0x3F
+        if pos + payload_len > len(data):
+            if logger:
+                logger.debug(
+                    "INVOCATION frame truncated at payload (offset=%d flags=0x%04x payload_len=%d remaining=%d).",
+                    frame_offset,
+                    flags,
+                    payload_len,
+                    len(data) - pos,
+                )
+            break
+
+        payload = data[pos : pos + payload_len]
+        pos += payload_len
+
+        frames.append(
+            InvocationFrame(
+                flags=flags,
+                opcode=opcode,
+                origin=origin,
+                target=target,
+                age=age,
+                origin_handle=origin_handle,
+                payload=payload,
+                offset=frame_offset,
+            )
+        )
+
+    if logger and pos != len(data):
+        logger.debug(
+            "INVOCATION stream: %d trailing bytes (parsed=%d total=%d).",
+            len(data) - pos,
+            pos,
+            len(data),
+        )
+
+    return frames

--- a/src/CasambiBt/_invocation.py
+++ b/src/CasambiBt/_invocation.py
@@ -4,6 +4,8 @@ import logging
 from dataclasses import dataclass
 from typing import Final
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, slots=True)
 class InvocationFrame:
@@ -36,9 +38,7 @@ class InvocationFrame:
 _FLAG_HAS_ORIGIN_HANDLE: Final[int] = 0x0200
 
 
-def parse_invocation_stream(
-    data: bytes, *, logger: logging.Logger | None = None
-) -> list[InvocationFrame]:
+def parse_invocation_stream(data: bytes) -> list[InvocationFrame]:
     """Parse decrypted packet type-7 payload into INVOCATION frames."""
 
     frames: list[InvocationFrame] = []
@@ -65,8 +65,8 @@ def parse_invocation_stream(
         origin_handle: int | None = None
         if flags & _FLAG_HAS_ORIGIN_HANDLE:
             if pos >= len(data):
-                if logger:
-                    logger.debug(
+                if _LOGGER:
+                    _LOGGER.debug(
                         "INVOCATION frame truncated at origin_handle (offset=%d flags=0x%04x).",
                         frame_offset,
                         flags,
@@ -77,8 +77,8 @@ def parse_invocation_stream(
 
         payload_len = flags & 0x3F
         if pos + payload_len > len(data):
-            if logger:
-                logger.debug(
+            if _LOGGER:
+                _LOGGER.debug(
                     "INVOCATION frame truncated at payload (offset=%d flags=0x%04x payload_len=%d remaining=%d).",
                     frame_offset,
                     flags,
@@ -103,8 +103,8 @@ def parse_invocation_stream(
             )
         )
 
-    if logger and pos != len(data):
-        logger.debug(
+    if _LOGGER and pos != len(data):
+        _LOGGER.debug(
             "INVOCATION stream: %d trailing bytes (parsed=%d total=%d).",
             len(data) - pos,
             pos,

--- a/src/CasambiBt/_switch.py
+++ b/src/CasambiBt/_switch.py
@@ -65,12 +65,12 @@ class SwitchEventDecoder:
     the same origin.
     """
 
-    def __init__(self, logger: logging.Logger | None = None) -> None:
-        self._logger = logger or _LOGGER
+    def __init__(self) -> None:
         # (unit_id, button_event_index, origin) -> monotonic timestamp of first acceptance
         # Storing all three dimensions lets us suppress a retransmit of event A even
         # after event B (different origin) has already been accepted for the same button.
         self._seen_origins: dict[tuple[int, int, int], float] = {}
+        self._logger = _LOGGER
 
     def reset(self) -> None:
         """Clear all cached state (call on reconnect)."""
@@ -91,7 +91,7 @@ class SwitchEventDecoder:
     def decode(self, data: bytes, packet_seq: int) -> list[SwitchEvent]:
         """Parse decrypted type-7 packet payload and return deduplicated switch events."""
 
-        frames = parse_invocation_stream(data, logger=self._logger)
+        frames = parse_invocation_stream(data)
         events: list[SwitchEvent] = []
 
         for frame in frames:

--- a/src/CasambiBt/_switch.py
+++ b/src/CasambiBt/_switch.py
@@ -1,9 +1,22 @@
 import logging
-from binascii import b2a_hex as b2a
 from dataclasses import dataclass
 from enum import Enum, unique
+from time import monotonic
+from typing import Final
+
+from ._invocation import parse_invocation_stream
 
 _LOGGER = logging.getLogger(__name__)
+
+_BUTTON_EVENT_MIN: Final[int] = 29  # FunctionButtonEvent0
+_BUTTON_EVENT_MAX: Final[int] = 36  # FunctionButtonEvent7
+_INPUT_EVENT_MIN: Final[int] = 64  # FunctionNotifyInput0
+_INPUT_EVENT_MAX: Final[int] = 71  # FunctionNotifyInput7
+
+_TARGET_TYPE_BUTTON: Final[int] = 0x06
+_TARGET_TYPE_INPUT: Final[int] = 0x12
+
+_DEDUP_WINDOW_SECONDS: Final[float] = 0.5
 
 
 @unique
@@ -15,242 +28,177 @@ class ButtonEventType(Enum):
     UNKNOWN = 0xFFFF
 
 
-# TODO: Add message type enum.
-# TODO: Add action type enum.
-
-
 @dataclass(frozen=True, repr=True)
 class SwitchEvent:
-    message_type: int
-    button: int
+    button_event_index: int  # 0-based index from protocol (opcode - base)
+    button: int  # 1-based label = button_event_index + 1
     unit_id: int
-    action: int | None
+    target_type: int  # 0x06 = button stream, 0x12 = input stream
     event: ButtonEventType
     flags: int
     extra_data: bytes
 
 
-def parseSwitchEvents(data: bytes, packet_seq: int) -> list[SwitchEvent]:
-    """Parse switch event packet which contains multiple message types."""
+class SwitchEventDecoder:
+    """Stateful decoder that filters BLE retransmissions of switch events.
 
-    # Log complete packet structure with marker
-    _LOGGER.debug(
-        f"[CASAMBI_SWITCH_PACKET] Full data #{packet_seq}: hex={b2a(data)} len={len(data)}"
-    )
+    Wireless switches (e.g. EnOcean PTM215B) emit each physical event on two
+    streams in the same BLE packet:
+      - 0x06 (button stream): PRESS / RELEASE via origin & 0x02
+      - 0x12 (input stream):  PRESS / RELEASE / HOLD / RELEASE_AFTER_HOLD via payload[0]
 
-    # Special handling for message type 0x29 - not a switch event
-    if len(data) >= 1 and data[0] == 0x29:
-        _LOGGER.debug(f"Ignoring message type 0x29 (not a switch event): {b2a(data)}")
-        return []
+    Both streams are retransmitted up to 3 times.  A single physical action
+    therefore produces up to 6 raw frames.
 
-    pos = 0
-    oldPos = 0
-    switch_events_found = 0
-    all_messages_found = []
-    switch_events = []
+    Stream responsibilities:
+      - 0x06 is the authoritative source for PRESS and RELEASE events.
+      - 0x12 is used exclusively for HOLD and RELEASE_AFTER_HOLD events.
+        Its PRESS (0x01) and RELEASE (0x02) codes are ignored because the 0x12
+        stream sends code=0x02 during a long hold (before the HOLD code=0x09
+        arrives), which would cause a spurious RELEASE event.
 
-    try:
-        while pos <= len(data) - 3:
-            oldPos = pos
+    Retransmit deduplication uses the `origin` field from each INVOCATION frame
+    as the event identity: all retransmissions of the same physical action share
+    an identical `origin` value, while a new physical action always carries a
+    different `origin` (the device increments its sequence counter).  A 500 ms
+    time window prevents a stale entry from masking a future genuine event with
+    the same origin.
+    """
 
-            # Parse message header
-            message_type = data[pos]
-            flags = data[pos + 1]
-            length = ((data[pos + 2] >> 4) & 15) + 1
-            parameter = data[pos + 2]  # Full byte, not just lower 4 bits
-            pos += 3
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or _LOGGER
+        # (unit_id, button_event_index, origin) -> monotonic timestamp of first acceptance
+        # Storing all three dimensions lets us suppress a retransmit of event A even
+        # after event B (different origin) has already been accepted for the same button.
+        self._seen_origins: dict[tuple[int, int, int], float] = {}
 
-            # Log every message found with detailed structure
-            _LOGGER.debug(
-                f"[CASAMBI_MSG_FOUND] At pos={oldPos}: type=0x{message_type:02x} flags=0x{flags:02x} "
-                f"len={length} param=0x{parameter:02x}"
-            )
+    def reset(self) -> None:
+        """Clear all cached state (call on reconnect)."""
+        self._seen_origins.clear()
 
-            # Sanity check: message type should be reasonable
-            if message_type > 0x80:
-                _LOGGER.debug(
-                    f"Skipping invalid message type 0x{message_type:02x} at position {oldPos}"
-                )
-                # Try to resync by looking for next valid message
-                pos = oldPos + 1
-                continue
+    def _is_retransmit(self, unit_id: int, button_index: int, origin: int) -> bool:
+        """Return True if this frame is a retransmit of a recently accepted event.
 
-            # Check if we have enough data for the payload
-            if pos + length > len(data):
-                _LOGGER.debug(
-                    f"Incomplete message at position {oldPos}. "
-                    f"Type: 0x{message_type:02x}, declared length: {length}, available: {len(data) - pos}"
-                )
-                break
+        Uses the protocol-level `origin` field as the event identity: all BLE
+        retransmissions of the same physical action share the same origin value,
+        while a new physical action always carries a different origin (the device
+        increments its sequence counter).  The time window guards against the edge
+        case where the same origin reappears after a very long gap.
+        """
+        ts = self._seen_origins.get((unit_id, button_index, origin))
+        return ts is not None and (monotonic() - ts) < _DEDUP_WINDOW_SECONDS
 
-            # Extract the payload
-            payload = data[pos : pos + length]
-            pos += length
+    def decode(self, data: bytes, packet_seq: int) -> list[SwitchEvent]:
+        """Parse decrypted type-7 packet payload and return deduplicated switch events."""
 
-            # Log the payload
-            _LOGGER.debug(
-                f"[CASAMBI_MSG_PAYLOAD] Type 0x{message_type:02x} payload: {b2a(payload)} "
-                f"(bytes {oldPos+3} to {oldPos+3+length-1})"
-            )
+        frames = parse_invocation_stream(data, logger=self._logger)
+        events: list[SwitchEvent] = []
 
-            # Track all messages
-            all_messages_found.append(
-                {
-                    "type": message_type,
-                    "pos": oldPos,
-                    "flags": flags,
-                    "param": parameter,
-                    "payload": b2a(payload),
-                }
-            )
+        for frame in frames:
+            target_type = frame.target & 0xFF
+            unit_id = frame.target >> 8
 
-            # Process based on message type
-            if message_type == 0x08 or message_type == 0x10:  # Switch/button events
-                switch_events_found += 1
+            if (
+                target_type == _TARGET_TYPE_BUTTON
+                and _BUTTON_EVENT_MIN <= frame.opcode <= _BUTTON_EVENT_MAX
+            ):
+                # Button stream: press/release encoded in bit 1 of origin low byte.
+                # Confirmed on PTM215B captures: is_release = (origin & 0x02) != 0
+                button_event_index = frame.opcode - _BUTTON_EVENT_MIN
+                is_release = bool(frame.origin & 0x02)
+                event = ButtonEventType.RELEASE if is_release else ButtonEventType.PRESS
 
-                # Button extraction differs between type 0x08 and type 0x10
-                if message_type == 0x08:
-                    # For type 0x08, the lower nibble is a code that maps to physical button id
-                    # Using formula: ((code + 2) % 4) + 1 based on reverse engineering findings
-                    code_nibble = parameter & 0x0F
-                    button = ((code_nibble + 2) % 4) + 1
-                    _LOGGER.debug(
-                        f"Type 0x08 button extraction: parameter=0x{parameter:02x}, code={code_nibble}, button={button}"
+                if self._is_retransmit(unit_id, button_event_index, frame.origin):
+                    self._logger.debug(
+                        "Suppressed retransmit (0x06): unit_id=%d button_index=%d event=%s origin=0x%04x",
+                        unit_id,
+                        button_event_index,
+                        event.name,
+                        frame.origin,
                     )
-                    full_message_data = data
-                elif message_type == 0x10:
-                    # For type 0x10, use existing logic
-                    button_lower = parameter & 0x0F
-                    button_upper = (parameter >> 4) & 0x0F
+                    continue
+                self._seen_origins[(unit_id, button_event_index, frame.origin)] = (
+                    monotonic()
+                )
 
-                    # Use upper 4 bits if lower 4 bits are 0, otherwise use lower 4 bits
-                    if button_lower == 0 and button_upper != 0:
-                        button = button_upper
-                        _LOGGER.debug(
-                            f"Type 0x10 button extraction: parameter=0x{parameter:02x}, using upper nibble, button={button}"
-                        )
-                    else:
-                        button = button_lower
-                        _LOGGER.debug(
-                            f"Type 0x10 button extraction: parameter=0x{parameter:02x}, using lower nibble, button={button}"
-                        )
-
-                    # For type 0x10 messages, we need to pass additional data beyond the declared payload
-                    # Extend to include at least 10 bytes from message start for state byte
-                    extended_end = min(oldPos + 11, len(data))
-                    full_message_data = data[oldPos:extended_end]
-
-                switch_events.append(
-                    _processSwitchMessage(
-                        message_type, flags, button, payload, full_message_data
+                events.append(
+                    SwitchEvent(
+                        button_event_index=button_event_index,
+                        button=button_event_index + 1,
+                        unit_id=unit_id,
+                        target_type=target_type,
+                        event=event,
+                        flags=frame.flags,
+                        extra_data=frame.payload,
                     )
                 )
-            elif message_type == 0x29:
-                # This shouldn't happen due to check above, but just in case
-                _LOGGER.debug("Ignoring embedded type 0x29 message")
-            elif message_type in [0x00, 0x06, 0x09, 0x1F, 0x2A]:
-                # Known non-switch message types - log at debug level
-                _LOGGER.debug(f"Non-switch message type 0x{message_type:02x}")
-            else:
-                # Unknown message types - log at info level
-                _LOGGER.info(f"Unknown message type 0x{message_type:02x}")
 
-            oldPos = pos
+            elif (
+                target_type == _TARGET_TYPE_INPUT
+                and _INPUT_EVENT_MIN <= frame.opcode <= _INPUT_EVENT_MAX
+            ):
+                # Input stream: payload[0] is the event type directly.
+                # Confirmed on PTM215B: 0x01=PRESS, 0x02=RELEASE, 0x09=HOLD, 0x0C=RELEASE_AFTER_HOLD
+                # PRESS and RELEASE are ignored here — 0x06 is authoritative for those.
+                # 0x12 sends code=0x02 during long holds before HOLD arrives, causing
+                # a spurious RELEASE event if we don't filter it out.
+                if not frame.payload:
+                    self._logger.debug(
+                        "Input stream frame with empty payload, skipping."
+                    )
+                    continue
+                button_event_index = frame.opcode - _INPUT_EVENT_MIN
+                try:
+                    event = ButtonEventType(frame.payload[0])
+                except ValueError:
+                    self._logger.debug(
+                        "Unknown input event code 0x%02x in input stream frame.",
+                        frame.payload[0],
+                    )
+                    event = ButtonEventType.UNKNOWN
 
-    except IndexError:
-        _LOGGER.warning("Ran out of data while parsing switch event packet!")
-        _LOGGER.info(f"Remaining data {b2a(data[oldPos:])} in {b2a(data)}.")
+                if event in (ButtonEventType.PRESS, ButtonEventType.RELEASE):
+                    self._logger.debug(
+                        "Ignored 0x12 %s (authoritative source is 0x06): unit_id=%d button_index=%d",
+                        event.name,
+                        unit_id,
+                        button_event_index,
+                    )
+                    continue
 
-    # Log summary of all messages found
-    _LOGGER.debug(
-        f"[CASAMBI_PARSE_SUMMARY] Packet #{packet_seq}: Found {len(all_messages_found)} messages, "
-        f"{switch_events_found} switch events"
-    )
-    for i, msg in enumerate(all_messages_found):
-        _LOGGER.debug(
-            f"[CASAMBI_MSG_{i+1}] Type=0x{msg['type']:02x} Pos={msg['pos']} "
-            f"Flags=0x{msg['flags']:02x} Param=0x{msg['param']:02x} Payload={msg['payload']}"
-        )
-
-    if switch_events_found == 0:
-        _LOGGER.info(f"No switch events found in packet: {b2a(data)}")
-
-    return switch_events
-
-
-def _processSwitchMessage(
-    message_type: int, flags: int, button: int, payload: bytes, full_data: bytes
-) -> SwitchEvent:
-    """Process a switch/button message (types 0x08 or 0x10)."""
-
-    assert len(payload) > 0
-
-    # Extract unit_id based on message type
-    if message_type == 0x10 and len(payload) >= 3:
-        # Type 0x10: unit_id is at payload[2]
-        unit_id = payload[2]
-        extra_data = payload[3:] if len(payload) > 3 else b""
-    else:
-        # Standard parsing for other message types
-        unit_id = payload[0]
-        extra_data = b""
-        if len(payload) > 2:
-            extra_data = payload[2:]
-
-    # Extract action based on message type (action SHOULD be different for press vs release)
-    if len(payload) > 1:
-        # Action is at payload[1]
-        action = payload[1]
-    else:
-        action = None
-
-    event = ButtonEventType.UNKNOWN
-
-    # Different interpretation based on message type
-    if message_type == 0x08:
-        # Type 0x08: Use bit 1 of action for press/release
-        if action is not None:
-            is_release = (action >> 1) & 1
-            event = ButtonEventType.RELEASE if is_release else ButtonEventType.PRESS
-    elif message_type == 0x10:
-        # Type 0x10: The state byte is at position 9 (0-indexed) from message start
-        # This applies to all units, not just unit 31
-        # full_data for type 0x10 is the message data starting from position 0
-        state_pos = 9
-        if len(full_data) > state_pos:
-            state_byte = full_data[state_pos]
-            if state_byte in ButtonEventType:
-                event = ButtonEventType(state_byte)
-            else:
-                _LOGGER.debug(
-                    f"Type 0x10: Unknown state byte 0x{state_byte:02x} at message pos {state_pos}"
-                )
-        else:
-            # Fallback when message is too short
-            if len(extra_data) >= 1 and extra_data[0] == 0x12:
-                event = ButtonEventType.RELEASE
-                _LOGGER.debug(
-                    "Type 0x10: Using extra_data pattern for release detection"
-                )
-            else:
-                # Cannot determine state
-                _LOGGER.warning(
-                    f"Type 0x10 message missing state info, unit_id={unit_id}, payload={b2a(payload)}"
+                if self._is_retransmit(unit_id, button_event_index, frame.origin):
+                    self._logger.debug(
+                        "Suppressed retransmit (0x12): unit_id=%d button_index=%d event=%s origin=0x%04x",
+                        unit_id,
+                        button_event_index,
+                        event.name,
+                        frame.origin,
+                    )
+                    continue
+                self._seen_origins[(unit_id, button_event_index, frame.origin)] = (
+                    monotonic()
                 )
 
-    action_display = f"{action:#04x}" if action is not None else "N/A"
+                events.append(
+                    SwitchEvent(
+                        button_event_index=button_event_index,
+                        button=button_event_index + 1,
+                        unit_id=unit_id,
+                        target_type=target_type,
+                        event=event,
+                        flags=frame.flags,
+                        extra_data=frame.payload[1:],
+                    )
+                )
 
-    _LOGGER.info(
-        f"Switch event (type 0x{message_type:02x}): button={button}, unit_id={unit_id}, "
-        f"action={action_display} ({event}), flags=0x{flags:02x}"
-    )
+            else:
+                self._logger.debug(
+                    "Ignoring INVOCATION frame: opcode=0x%02x target_type=0x%02x.",
+                    frame.opcode,
+                    target_type,
+                )
 
-    # Log detailed info about type 0x08 messages (now processed, not filtered)
-    if message_type == 0x08:
-        _LOGGER.debug(
-            f"[CASAMBI_TYPE08_PROCESSED] Type 0x08 event processed: button={button}, unit_id={unit_id}, "
-            f"action={action_display}, event={event}, flags=0x{flags:02x}, "
-            f"payload={b2a(payload)}, extra_data={b2a(extra_data) if extra_data else 'none'}"
-        )
+        if not events:
+            self._logger.debug("No switch events found in packet #%s.", packet_seq)
 
-    return SwitchEvent(message_type, button, unit_id, action, event, flags, extra_data)
+        return events

--- a/tests/test_casambi.py
+++ b/tests/test_casambi.py
@@ -380,11 +380,11 @@ def test_data_callback_switch_event(connected_casambi):
     connected_casambi.registerSwitchEventHandler(handler)
 
     event = SwitchEvent(
-        unit_id=1,
+        button_event_index=0,
         button=1,
+        unit_id=1,
+        target_type=0x06,
         event=ButtonEventType.PRESS,
-        action=1,
-        message_type=0x08,
         flags=0x00,
         extra_data=b"",
     )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,244 @@
+"""Tests for SwitchEventDecoder — origin-based retransmit deduplication."""
+
+import struct
+from time import monotonic
+
+from CasambiBt._switch import (
+    _DEDUP_WINDOW_SECONDS,
+    _TARGET_TYPE_BUTTON,
+    _TARGET_TYPE_INPUT,
+    ButtonEventType,
+    SwitchEventDecoder,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers to build raw INVOCATION frames
+# ---------------------------------------------------------------------------
+# Frame layout (from _invocation.py):
+#   flags:u16 (big-endian)  — low 6 bits = payload_len
+#   opcode:u8
+#   origin:u16 (big-endian)
+#   target:u16 (big-endian) — low byte = target_type, high byte = unit_id
+#   age:u16 (big-endian)
+#   payload: payload_len bytes
+
+_OPCODE_BUTTON_0 = 29  # FunctionButtonEvent0 → button 1
+_OPCODE_INPUT_0 = 64  # FunctionNotifyInput0 → button 1
+_UNIT_ID = 0x15
+_AGE = 0x0001
+
+
+def _button_frame(origin: int, payload: bytes = b"\xf9") -> bytes:
+    """Build a 0x06 button-stream INVOCATION frame.
+
+    Pass the raw origin value directly.  The decoder derives PRESS/RELEASE from
+    bit 1: origin & 0x02 == 0 → PRESS, != 0 → RELEASE.
+
+    Typical PTM215B pattern:
+      - PRESS:   origin = 0xXXX0  (bit 1 clear)
+      - RELEASE: origin = 0xXXX2  (bit 1 set, same counter bits)
+      - Next physical event: counter bits incremented (e.g. 0xXXX4 / 0xXXX6)
+    """
+    payload_len = len(payload)
+    flags = payload_len & 0x3F
+    target = (_UNIT_ID << 8) | _TARGET_TYPE_BUTTON
+    return (
+        struct.pack(">HBHHH", flags, _OPCODE_BUTTON_0, origin, target, _AGE) + payload
+    )
+
+
+def _input_frame(origin: int, event_code: int, payload_extra: bytes = b"") -> bytes:
+    """Build a 0x12 input-stream INVOCATION frame."""
+    payload = bytes([event_code]) + payload_extra
+    payload_len = len(payload)
+    flags = payload_len & 0x3F
+    target = (_UNIT_ID << 8) | _TARGET_TYPE_INPUT
+    return struct.pack(">HBHHH", flags, _OPCODE_INPUT_0, origin, target, _AGE) + payload
+
+
+# ---------------------------------------------------------------------------
+# 0x06 button stream tests
+# ---------------------------------------------------------------------------
+
+
+class TestButtonStreamDedup:
+    # PTM215B origin convention used in these tests:
+    #   0xXXX0 → PRESS  (bit 1 = 0)
+    #   0xXXX2 → RELEASE (bit 1 = 1, same counter bits)
+    #   0xXXX4 → next physical PRESS  (counter incremented, bit 1 = 0)
+
+    def test_sequential_retransmits_deduplicated(self):
+        """3 identical PRESS frames (same origin) → exactly 1 PRESS emitted."""
+        dec = SwitchEventDecoder()
+        frame = _button_frame(origin=0x15B0)  # PRESS (bit 1 = 0)
+
+        results = []
+        for _ in range(3):
+            results.extend(dec.decode(frame, packet_seq=1))
+
+        assert len(results) == 1
+        assert results[0].event == ButtonEventType.PRESS
+
+    def test_press_then_release_both_emitted(self):
+        """PRESS (origin 0x15B0) then RELEASE (origin 0x15B2) → both emitted."""
+        dec = SwitchEventDecoder()
+        press_frame = _button_frame(origin=0x15B0)  # bit 1 = 0 → PRESS
+        release_frame = _button_frame(origin=0x15B2)  # bit 1 = 1 → RELEASE
+
+        results = dec.decode(press_frame, packet_seq=1)
+        results += dec.decode(release_frame, packet_seq=2)
+
+        assert len(results) == 2
+        assert results[0].event == ButtonEventType.PRESS
+        assert results[1].event == ButtonEventType.RELEASE
+
+    def test_late_press_retransmit_after_release_suppressed(self):
+        """Core regression test: late PRESS retransmit (same origin) arriving
+        after RELEASE must be suppressed, not emitted as a phantom PRESS."""
+        dec = SwitchEventDecoder()
+        press_frame = _button_frame(origin=0x15B0)  # PRESS
+        release_frame = _button_frame(origin=0x15B2)  # RELEASE (different origin)
+        late_press_retransmit = _button_frame(origin=0x15B0)  # same origin as PRESS
+
+        results = dec.decode(press_frame, packet_seq=1)  # PRESS accepted
+        results += dec.decode(release_frame, packet_seq=2)  # RELEASE accepted
+        results += dec.decode(late_press_retransmit, packet_seq=3)  # must be suppressed
+
+        assert len(results) == 2
+        assert results[0].event == ButtonEventType.PRESS
+        assert results[1].event == ButtonEventType.RELEASE
+
+    def test_genuine_second_press_accepted_with_new_origin(self):
+        """A new physical PRESS (different origin, counter incremented) is accepted
+        immediately even within the dedup window."""
+        dec = SwitchEventDecoder()
+        first_press = _button_frame(origin=0x15B0)  # PRESS, counter N
+        release = _button_frame(origin=0x15B2)  # RELEASE, counter N
+        second_press = _button_frame(origin=0x15B4)  # PRESS, counter N+1 (new origin)
+
+        results = dec.decode(first_press, packet_seq=1)
+        results += dec.decode(release, packet_seq=2)
+        results += dec.decode(second_press, packet_seq=3)
+
+        assert len(results) == 3
+        assert results[0].event == ButtonEventType.PRESS
+        assert results[1].event == ButtonEventType.RELEASE
+        assert results[2].event == ButtonEventType.PRESS
+
+    def test_same_origin_accepted_after_window_expires(self):
+        """Edge case: after the dedup window expires, the same origin is accepted
+        again (guards against sequence counter wrap-around)."""
+        dec = SwitchEventDecoder()
+        origin = 0x15B0
+        frame = _button_frame(origin=origin)
+
+        # Inject a stale entry as if it was recorded before the window.
+        past = monotonic() - _DEDUP_WINDOW_SECONDS - 0.1
+        dec._seen_origins[(_UNIT_ID, 0, origin)] = past
+
+        results = dec.decode(frame, packet_seq=1)
+
+        assert len(results) == 1
+        assert results[0].event == ButtonEventType.PRESS
+
+    def test_different_origin_always_accepted_within_window(self):
+        """Even within the window, a different origin (genuine new event) is accepted."""
+        dec = SwitchEventDecoder()
+        first_press = _button_frame(origin=0xAAA0)  # PRESS
+        second_press = _button_frame(origin=0xAAA4)  # new PRESS, different counter
+
+        results = dec.decode(first_press, packet_seq=1)
+        results += dec.decode(second_press, packet_seq=2)
+
+        assert len(results) == 2
+
+    def test_button_label_is_one_based(self):
+        """button field must equal button_event_index + 1."""
+        dec = SwitchEventDecoder()
+        frame = _button_frame(origin=0x1000)
+        events = dec.decode(frame, packet_seq=1)
+        assert events[0].button == events[0].button_event_index + 1
+
+    def test_unit_id_and_target_type_extracted(self):
+        """unit_id and target_type are correctly parsed from the target field."""
+        dec = SwitchEventDecoder()
+        frame = _button_frame(origin=0x1000)
+        events = dec.decode(frame, packet_seq=1)
+        assert events[0].unit_id == _UNIT_ID
+        assert events[0].target_type == _TARGET_TYPE_BUTTON
+
+
+# ---------------------------------------------------------------------------
+# 0x12 input stream tests (HOLD / RELEASE_AFTER_HOLD)
+# ---------------------------------------------------------------------------
+
+
+class TestInputStreamDedup:
+    def test_hold_retransmits_deduplicated(self):
+        """3 identical HOLD frames → exactly 1 HOLD emitted."""
+        dec = SwitchEventDecoder()
+        frame = _input_frame(origin=0x15C0, event_code=0x09)  # HOLD
+
+        results = []
+        for _ in range(3):
+            results.extend(dec.decode(frame, packet_seq=1))
+
+        assert len(results) == 1
+        assert results[0].event == ButtonEventType.HOLD
+
+    def test_press_and_release_from_input_stream_ignored(self):
+        """0x12 PRESS and RELEASE are authoritative only from 0x06 → ignored here."""
+        dec = SwitchEventDecoder()
+        press_frame = _input_frame(origin=0x0001, event_code=0x01)  # PRESS code
+        release_frame = _input_frame(origin=0x0002, event_code=0x02)  # RELEASE code
+
+        results = dec.decode(press_frame, packet_seq=1)
+        results += dec.decode(release_frame, packet_seq=2)
+
+        assert results == []
+
+    def test_late_hold_retransmit_suppressed(self):
+        """HOLD retransmit arriving after RELEASE_AFTER_HOLD is accepted is suppressed."""
+        dec = SwitchEventDecoder()
+        hold_origin = 0x15C0
+        rah_origin = 0x15C1
+
+        hold_frame = _input_frame(origin=hold_origin, event_code=0x09)
+        rah_frame = _input_frame(origin=rah_origin, event_code=0x0C)
+        late_hold = _input_frame(origin=hold_origin, event_code=0x09)
+
+        results = dec.decode(hold_frame, packet_seq=1)
+        results += dec.decode(rah_frame, packet_seq=2)
+        results += dec.decode(late_hold, packet_seq=3)
+
+        assert len(results) == 2
+        assert results[0].event == ButtonEventType.HOLD
+        assert results[1].event == ButtonEventType.RELEASE_AFTER_HOLD
+
+
+# ---------------------------------------------------------------------------
+# State reset tests
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_clears_dedup_state(self):
+        """After reset(), a frame with the same origin as a prior event is accepted."""
+        dec = SwitchEventDecoder()
+        origin = 0x15B0
+        frame = _button_frame(origin=origin)
+
+        dec.decode(frame, packet_seq=1)  # accepted, origin recorded
+        dec.reset()
+        results = dec.decode(frame, packet_seq=2)  # same origin, but state cleared
+
+        assert len(results) == 1
+        assert results[0].event == ButtonEventType.PRESS
+
+    def test_reset_called_on_reconnect_does_not_suppress_first_event(self):
+        """After reconnect (reset), the very first event is never suppressed."""
+        dec = SwitchEventDecoder()
+        dec.reset()
+        frame = _button_frame(origin=0xDEAD)
+        results = dec.decode(frame, packet_seq=1)
+        assert len(results) == 1


### PR DESCRIPTION
## Summary

This PR implements robust switch event decoding, superseding the approach in #51 with an architecture aligned to the Casambi INVOCATION frame format.

### Key improvements over #51

- **INVOCATION frame decoder**: adds `_invocation.py`, a reusable parser for the Casambi INVOCATION frame format. `_switch.py` uses `FunctionButtonEvent` (opcodes 0x1D–0x24) and `FunctionNotifyInput` (opcodes 0x40–0x47) opcodes instead of the empirical 0x08/0x10 parsing in #51.

- **Origin-based retransmit dedup**: BLE retransmissions of the same physical event share the same `origin` field in the protocol. `SwitchEventDecoder` suppresses duplicates within a 500ms window keyed on `(unit_id, button_event_index, origin)`. This fixes a phantom-event bug where a late PRESS retransmit would fire *after* the RELEASE was already accepted, triggering spurious HA automations.

- **Stream separation**: stream `0x06` is authoritative for PRESS/RELEASE; stream `0x12` is the exclusive source for HOLD and RELEASE_AFTER_HOLD. Accepting PRESS/RELEASE from `0x12` causes spurious events during long-press sequences because both streams carry the same physical action.

- **Comprehensive test suite**: 13 test cases covering all event types, retransmit dedup, multi-button scenarios, reconnect state reset, and stream separation.

### API changes

`SwitchEvent` gains two new fields and loses two:

| Before | After |
|--------|-------|
| `message_type: int` (0x08 / 0x10) | `target_type: int` (0x06 / 0x12) |
| `action: int` | `button_event_index: int` (0-based, from opcode) |

`parseSwitchEvents()` is replaced by the `SwitchEventDecoder` class. Callers instantiate once and call `decode(payload, packet_count)`. Call `reset()` on disconnect to clear the dedup cache.

Supersedes #51.