### PR TITLE
Release the global cache lock when __aenter__ is cancelled

### DIFF
--- a/src/CasambiBt/_cache.py
+++ b/src/CasambiBt/_cache.py
@@ -72,10 +72,16 @@ class Cache:
     async def __aenter__(self) -> Path:
         await _cacheLock.acquire()
 
-        if self._uuid is None:
-            raise ValueError("UUID not set.")
-
+        # Everything after the acquire must release the lock on any failure.
+        # BaseException (not Exception) because asyncio.CancelledError derives
+        # from BaseException: the awaits below are cancellation points, and a
+        # caller wrapping us in asyncio.timeout() would otherwise leak the
+        # global lock permanently, deadlocking every later cache access for
+        # the lifetime of the process.
         try:
+            if self._uuid is None:
+                raise ValueError("UUID not set.")
+
             await self._ensureCacheValid()
 
             cacheDir = Path(self._cachePath / self._uuid)
@@ -85,7 +91,7 @@ class Cache:
 
             _LOGGER.debug("Returning cache path %s for id %s.", cacheDir, self._uuid)
             return cacheDir
-        except Exception:
+        except BaseException:
             _cacheLock.release()
             raise
 


### PR DESCRIPTION
### Problem

`Cache.__aenter__` acquires the module-global `_cacheLock`, then awaits `_ensureCacheValid()` and `cacheDir.exists()`. Those are cancellation points, so a caller that wraps cache access in `asyncio.timeout()` can be cancelled while holding the lock.

The cleanup handler is `except Exception:`, but `asyncio.CancelledError` derives from `BaseException` — so it doesn't run, and `__aexit__` is never reached. Since `_cacheLock` is module-global, the lock stays held **for the lifetime of the process**, and every later cache access deadlocks. Constructing a fresh `Casambi`/`Cache` doesn't help, because a new object doesn't get a new lock.

There's a second, smaller leak on the same path: `raise ValueError("UUID not set.")` happens after the acquire but outside the `try`.

### How it shows up

Hit this in Home Assistant via `casambi-bt-hass`, which wraps `connect()` in `asyncio.timeout(30)`. One slow BLE connect leaked the lock:

```
File "CasambiBt/_casambi.py", line 138, in connect
    await self._casaNetwork.load()
File "CasambiBt/_network.py", line 71, in _loadSession
    async with self._cache as cachePath:
File "CasambiBt/_cache.py", line 79, in __aenter__
    await self._ensureCacheValid()
File "CasambiBt/_cache.py", line 67, in _ensureCacheValid
    if not await self._cachePath.exists():
```

and every reconnect afterwards blocked one step earlier, until the same 30s timeout:

```
File "CasambiBt/_casambi.py", line 136, in connect
    await self._cache.setUuid(uuid)
File "CasambiBt/_cache.py", line 39, in setUuid
    async with _cacheLock:
asyncio.exceptions.CancelledError
```

That retried every ~90s for four hours. Only restarting the whole Home Assistant process recovered it.

### Fix

Catch `BaseException` so cancellation releases the lock, and move the UUID check inside the `try`.

### Verification

Standalone repro driving `Cache` the way the HA integration does — cancel inside `__aenter__`, then retry with a fresh `Cache` instance:

```
[BEFORE fix] after cancelled attempt, global lock held = True
[BEFORE fix] RESULT: DEADLOCKED — setUuid still blocked on global lock

[AFTER fix ] after cancelled attempt, global lock held = False
[AFTER fix ] RESULT: recovered — setUuid succeeded on retry
```