### PR TITLE
Improve recovery from disconnected Bluetooth writes

### DIFF
--- a/src/CasambiBt/_casambi.py
+++ b/src/CasambiBt/_casambi.py
@@ -50,6 +50,7 @@ class Casambi:
         self._unitChangedCallbacks: list[Callable[[Unit], None]] = []
         self._switchEventCallbacks: list[Callable[[SwitchEvent], None]] = []
         self._disconnectCallbacks: list[Callable[[], None]] = []
+        self._connectionLock = asyncio.Lock()
 
         self._logger = logging.getLogger(__name__)
         self._opContext: OperationsContext
@@ -175,14 +176,17 @@ class Casambi:
         """
 
         self._checkNetwork()
-        if self._casaClient is None:
-            raise ConnectionStateError(
-                ConnectionState.CONNECTED,
-                ConnectionState.NONE,
-                "Reconnect only possible after initial connection and before disconnect.",
-            )
-        await self._casaClient.disconnect()
-        await self._connectClient(addr_or_device)
+        async with self._connectionLock:
+            if self._casaClient is None:
+                raise ConnectionStateError(
+                    ConnectionState.CONNECTED,
+                    ConnectionState.NONE,
+                    "Reconnect only possible after initial connection and before disconnect.",
+                )
+            if self.connected:
+                return
+            await self._casaClient.disconnect()
+            await self._connectClient(addr_or_device)
 
     async def _connectClient(self, addr_or_device: str | BLEDevice) -> None:
         """Initiate the bluetooth connection."""
@@ -528,7 +532,7 @@ class Casambi:
         except ConnectionStateError as exc:
             if exc.got == ConnectionState.NONE:
                 self._logger.info("Trying to reconnect broken connection once.")
-                await self._connectClient(self._casaClient._address_or_devive)
+                await self.reconnect(self._casaClient._address_or_devive)
                 await self._casaClient.send(opPkt)
             else:
                 raise exc

--- a/src/CasambiBt/_client.py
+++ b/src/CasambiBt/_client.py
@@ -625,13 +625,15 @@ class CasambiClientEvolution(CasambiClient):
         try:
             await self._gattClient.write_gatt_char(char, encPacket)
         except BleakError as e:
-            if e.args[0] == "Not connected":
+            if e.args and e.args[0] == "Not connected":
                 self._logger.debug(
                     "Unexpected write while disconnected.", exc_info=True
                 )
                 self._connectionState = ConnectionState.NONE
-            else:
-                raise BluetoothError from e
+                raise ConnectionStateError(
+                    ConnectionState.AUTHENTICATED, ConnectionState.NONE
+                ) from e
+            raise BluetoothError from e
 
     def _getNonce(self, id: int | bytes) -> bytes:
         if isinstance(id, int):
@@ -850,10 +852,12 @@ class CasambiClientClassic(CasambiClient):
         try:
             await self._gattClient.write_gatt_char(CASA_AUTH_CHAR_UUID, outPacket)
         except BleakError as e:
-            if e.args[0] == "Not connected":
+            if e.args and e.args[0] == "Not connected":
                 self._logger.debug(
                     "Unexpected write while disconnected.", exc_info=True
                 )
                 self._connectionState = ConnectionState.NONE
-            else:
-                raise BluetoothError from e
+                raise ConnectionStateError(
+                    ConnectionState.AUTHENTICATED, ConnectionState.NONE
+                ) from e
+            raise BluetoothError from e

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,6 +253,20 @@ async def test_send_success(client):
     )
 
 
+async def test_send_not_connected_raises_connection_state_error(client):
+    client._connectionState = ConnectionState.AUTHENTICATED
+    client._gattClient = AsyncMock()
+    client._nonce = b"1234567890123456"
+    client._encryptor = MagicMock()
+    client._encryptor.encryptThenMac.return_value = b"encrypted_payload"
+    client._gattClient.write_gatt_char.side_effect = BleakError("Not connected")
+
+    with pytest.raises(ConnectionStateError):
+        await client.send(b"\x01\x02")
+
+    assert client._connectionState == ConnectionState.NONE
+
+
 async def test_send_wrong_state(client):
     client._connectionState = ConnectionState.CONNECTED
     with pytest.raises(ConnectionStateError):

--- a/tests/test_client_classic.py
+++ b/tests/test_client_classic.py
@@ -2,6 +2,7 @@ import struct
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from bleak.exc import BleakError
 
 from CasambiBt._client import CasambiClientClassic
 from CasambiBt._constants import (
@@ -14,7 +15,11 @@ from CasambiBt._constants import (
     IncomingPacketType,
 )
 from CasambiBt._network import Network
-from CasambiBt.errors import ProtocolError, UnsupportedProtocolVersion
+from CasambiBt.errors import (
+    ConnectionStateError,
+    ProtocolError,
+    UnsupportedProtocolVersion,
+)
 
 
 @pytest.fixture
@@ -195,6 +200,20 @@ async def test_sendInternal_manager(client):
     args = client._gattClient.write_gatt_char.call_args[0]
     assert args[0] == CASA_AUTH_CHAR_UUID
     assert args[1].startswith(b"\x03")
+
+
+async def test_send_internal_not_connected_raises_connection_state_error(client):
+    client._connectionState = ConnectionState.AUTHENTICATED
+    client._gattClient = AsyncMock()
+    client._connhash = b"12345678"
+    client._managerEncryptor = MagicMock()
+    client._managerEncryptor.digest.return_value = b"encrypted_packet"
+    client._gattClient.write_gatt_char.side_effect = BleakError("Not connected")
+
+    with pytest.raises(ConnectionStateError):
+        await client._sendInternal(b"\x12\x34")
+
+    assert client._connectionState == ConnectionState.NONE
 
 
 async def test_sendInternal_visitor(


### PR DESCRIPTION
Related to lkempf/casambi-bt-hass#154.

This fixes several related problems in the Bluetooth connection recovery path.

### Propagate disconnected GATT writes

Both the Evolution and Classic clients currently catch `BleakError("Not connected")`, set their internal state to `NONE`, and then return as if the write had succeeded.

This prevents higher-level recovery from seeing the failed write.

The clients now raise `ConnectionStateError` after changing the state to `NONE`, allowing `Casambi._send()` to invoke its recovery path.

The Bleak error arguments are also checked before accessing the first item.

### Use the normal reconnect lifecycle

When `_send()` encountered `ConnectionState.NONE`, it called `_connectClient()` directly.

This bypassed `reconnect()` and could race with another reconnect already running, for example one initiated by the Home Assistant integration.

Reconnect operations are now serialized with an `asyncio.Lock`, and `_send()` uses `reconnect()` instead of constructing a new client directly.

If another reconnect restored the connection while waiting for the lock, the second reconnect becomes a no-op.

### Tests

Regression tests cover the `"Not connected"` write path for both Evolution and Classic clients.

The project formatting, linting, type checking and test suite pass locally.

These changes were developed while investigating the recurring connection-loss behaviour reported in lkempf/casambi-bt-hass#154.